### PR TITLE
Add TypeScript types

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -136,17 +136,7 @@ export interface Path2DBounds {
 }
 
 type _Values<T extends {}> = T[keyof T]
-export type Path2DEdge = _Values<{
-  [P in
-    | "moveTo"
-    | "lineTo"
-    | "quadraticCurveTo"
-    | "bezierCurveTo"
-    | "conicCurveTo"
-    | "closePath"]: Path2D[P] extends (...args: any) => void
-    ? [P, ...Parameters<Path2D[P]>]
-    : never
-}>
+export type Path2DEdge = [verb: string, ...args: number[]]
 
 export class Path2D extends globalThis.Path2D {
   readonly bounds: Path2DBounds

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -132,7 +132,6 @@ export interface Path2DBounds {
   readonly height: number
 }
 
-type _Values<T extends {}> = T[keyof T]
 export type Path2DEdge = [verb: string, ...args: number[]]
 
 export class Path2D extends globalThis.Path2D {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -63,7 +63,7 @@ export interface CreateTextureOptions {
   line?: number
   color?: string
   angle?: number
-  offset?: [x: number, y: number]
+  offset?: [x: number, y: number] | number
 }
 
 export class CanvasRenderingContext2D extends globalThis.CanvasRenderingContext2D {
@@ -75,7 +75,7 @@ export class CanvasRenderingContext2D extends globalThis.CanvasRenderingContext2
   textWrap: boolean
 
   lineDashFit: "move" | "turn" | "follow"
-  lineDashMarker: Path2D
+  lineDashMarker: Path2D | null
 
   conicCurveTo(
     cpx: number,

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -100,9 +100,6 @@ export class CanvasRenderingContext2D extends globalThis.CanvasRenderingContext2
     | CanvasTexture
   // @ts-expect-error We're rewriting the canvas property in a non-typesafe way
   fillStyle: globalThis.CanvasRenderingContext2D["fillStyle"] | CanvasTexture
-
-  /** @internal */
-  lineStyle: string
 }
 
 export interface TextMetrics extends globalThis.TextMetrics {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,228 @@
+/// <reference types="node" />
+
+export interface RenderOptions {
+  page?: number
+  density?: number
+  quality?: number | undefined
+  outline?: boolean
+}
+
+export interface SaveOptions extends RenderOptions {
+  format?: string | undefined
+  matte?: string
+}
+
+export class Canvas {
+  /** @internal */
+  static contexts: WeakMap<Canvas, readonly CanvasRenderingContext2D[]>
+
+  constructor(width?: number, height?: number)
+
+  /**
+   * Cast this object as a {@link SyncCanvas} and set the `async` property to false to get the synchronous behaviours.
+   *
+   * @example
+   * import { Canvas, SyncCanvas } from "."
+   * const myCanvas = new Canvas() as any as SyncCanvas
+   * myCanvas.async = false
+   * const result = myCanvas.toBuffer("png") // now these functions return synchronously
+   */
+  async: true
+
+  get width(): number
+  get height(): number
+
+  getContext(type?: "2d"): CanvasRenderingContext2D
+
+  get pages(): readonly CanvasRenderingContext2D[]
+
+  get pdf(): Promise<Buffer>
+  get svg(): Promise<Buffer>
+  get jpg(): Promise<Buffer>
+  get png(): Promise<Buffer>
+
+  newPage(width?: number, height?: number): CanvasRenderingContext2D
+
+  saveAs(filename: string, options?: SaveOptions): Promise<void>
+  toBuffer(format: string, options?: RenderOptions): Promise<Buffer>
+  toDataURL(format: string, options?: RenderOptions): Promise<string>
+}
+
+export type SyncCanvas = {
+  [P in keyof Canvas]: Canvas[P] extends Promise<infer Value>
+    ? Value // Promise getter to synchronous getter
+    : Canvas[P] extends (...args: infer Args) => Promise<infer Return>
+    ? (...args: Args) => Return // Async functions to sync functions
+    : P extends "async"
+    ? false // `async` property is now false
+    : Canvas[P] // Everything else stays the same
+}
+
+export interface CreateTextureOptions {
+  path?: Path2D
+  line?: number
+  color?: string
+  angle?: number
+  offset?: [x: number, y: number]
+}
+
+export class CanvasRenderingContext2D extends globalThis.CanvasRenderingContext2D {
+  // @ts-expect-error We're rewriting the canvas property in a non-typesafe way
+  readonly canvas: Canvas
+
+  fontVariant: string
+  textTracking: number
+  textWrap: boolean
+
+  lineDashFit: "move" | "turn" | "follow"
+  lineDashMarker: Path2D
+
+  conicCurveTo(
+    cpx: number,
+    cpy: number,
+    x: number,
+    y: number,
+    weight: number
+  ): void
+
+  createTexture(
+    spacing: number | [width: number, height: number],
+    options?: CreateTextureOptions
+  ): CanvasTexture
+
+  measureText(text: string, maxWidth?: number): TextMetrics
+
+  outlineText(text: string): Path2D
+
+  // @ts-expect-error We're rewriting the canvas property in a non-typesafe way
+  strokeStyle:
+    | globalThis.CanvasRenderingContext2D["strokeStyle"]
+    | CanvasTexture
+  // @ts-expect-error We're rewriting the canvas property in a non-typesafe way
+  fillStyle: globalThis.CanvasRenderingContext2D["fillStyle"] | CanvasTexture
+
+  /** @internal */
+  lineStyle: string
+}
+
+export interface TextMetrics extends globalThis.TextMetrics {
+  lines: TextMetricsLine[]
+}
+
+export interface TextMetricsLine {
+  readonly x: number
+  readonly y: number
+  readonly width: number
+  readonly height: number
+  readonly baseline: number
+  readonly startIndex: number
+  readonly endIndex: number
+}
+
+export class CanvasTexture {}
+export class CanvasGradient extends globalThis.CanvasGradient {}
+export class CanvasPattern extends globalThis.CanvasPattern {}
+export class DOMMatrix extends globalThis.DOMMatrix {}
+export class Image extends globalThis.Image {}
+export class ImageData extends globalThis.ImageData {}
+
+export interface Path2DBounds {
+  readonly top: number
+  readonly left: number
+  readonly bottom: number
+  readonly right: number
+  readonly width: number
+  readonly height: number
+}
+
+type _Values<T extends {}> = T[keyof T]
+export type Path2DEdge = _Values<{
+  [P in
+    | "moveTo"
+    | "lineTo"
+    | "quadraticCurveTo"
+    | "bezierCurveTo"
+    | "conicCurveTo"
+    | "closePath"]: Path2D[P] extends (...args: any) => void
+    ? [P, ...Parameters<Path2D[P]>]
+    : never
+}>
+
+export class Path2D extends globalThis.Path2D {
+  readonly bounds: Path2DBounds
+  d: string
+  readonly edges: readonly Path2DEdge[]
+
+  contains(x: number, y: number): boolean
+
+  complement(otherPath: Path2D): Path2D
+  difference(otherPath: Path2D): Path2D
+  intersect(otherPath: Path2D): Path2D
+  union(otherPath: Path2D): Path2D
+  xor(otherPath: Path2D): Path2D
+
+  interpolate(otherPath: Path2D, weight: number): Path2D
+
+  jitter(segmentLength: number, amount: number, seed?: number): Path2D
+
+  offset(dx: number, dy: number): Path2D
+
+  points(step?: number): readonly [x: number, y: number][]
+
+  round(radius: number): Path2D
+
+  simplify(rule?: "nonzero" | "evenodd"): Path2D
+
+  transform(matrix: DOMMatrix): Path2D
+  transform(
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    e: number,
+    f: number
+  ): Path2D
+
+  trim(start: number, end?: number, inverted?: boolean): Path2D
+
+  unwind(): Path2D
+
+  conicCurveTo(
+    cpx: number,
+    cpy: number,
+    x: number,
+    y: number,
+    weight: number
+  ): void
+}
+
+export function loadImage(src: string | Buffer): Promise<Image>
+
+export interface FontFamily {
+  family: string
+  weights: number[]
+  widths: string[]
+  styles: string[]
+}
+
+export interface FontVariant {
+  family: string
+  weight: number
+  style: string
+  width: string
+  file: string
+}
+
+export interface FontLibrary {
+  families: readonly string[]
+  family(name: string): FontFamily | undefined
+  has(familyName: string): boolean
+
+  use(familyName: string, fontPaths?: string | readonly string[]): FontVariant[]
+  use(fontPaths: readonly string[]): FontVariant[]
+  use(
+    families: Record<string, readonly string[] | string>
+  ): Record<string, FontVariant[] | FontVariant>
+}
+
+export const FontLibrary: FontLibrary

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "string-split-by": "^1.0.0"
       },
       "devDependencies": {
+        "@types/jest": "^27.0.3",
         "@types/node": "^10.17.60",
         "aws-sdk": "^2.1013.0",
         "cargo-cp-artifact": "^0.1",
@@ -1081,6 +1082,16 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "27.0.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.3.tgz",
+      "integrity": "sha512-cmmwv9t7gBYt7hNKH5Spu7Kuu/DotGa+Ff+JGRKZ4db5eh8PnKS4LuebJ3YLUoyOyIHraTGyULn23YtEAm0VSg==",
+      "dev": true,
+      "dependencies": {
+        "jest-diff": "^27.0.0",
+        "pretty-format": "^27.0.0"
       }
     },
     "node_modules/@types/node": {
@@ -6998,6 +7009,16 @@
       "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "27.0.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.3.tgz",
+      "integrity": "sha512-cmmwv9t7gBYt7hNKH5Spu7Kuu/DotGa+Ff+JGRKZ4db5eh8PnKS4LuebJ3YLUoyOyIHraTGyULn23YtEAm0VSg==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^27.0.0",
+        "pretty-format": "^27.0.0"
       }
     },
     "@types/node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "string-split-by": "^1.0.0"
       },
       "devDependencies": {
+        "@types/node": "^10.17.60",
         "aws-sdk": "^2.1013.0",
         "cargo-cp-artifact": "^0.1",
         "express": "^4.17.1",
@@ -1083,9 +1084,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.11.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.4.tgz",
-      "integrity": "sha512-TMgXmy0v2xWyuCSCJM6NCna2snndD8yvQF67J29ipdzMcsPa9u+o0tjF5+EQNdhcuZplYuouYqpc4zcd5I6amQ==",
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -7000,9 +7001,9 @@
       }
     },
     "@types/node": {
-      "version": "16.11.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.4.tgz",
-      "integrity": "sha512-TMgXmy0v2xWyuCSCJM6NCna2snndD8yvQF67J29ipdzMcsPa9u+o0tjF5+EQNdhcuZplYuouYqpc4zcd5I6amQ==",
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
       "dev": true
     },
     "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "string-split-by": "^1.0.0"
   },
   "devDependencies": {
+    "@types/jest": "^27.0.3",
     "@types/node": "^10.17.60",
     "aws-sdk": "^2.1013.0",
     "cargo-cp-artifact": "^0.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "string-split-by": "^1.0.0"
   },
   "devDependencies": {
+    "@types/node": "^10.17.60",
     "aws-sdk": "^2.1013.0",
     "cargo-cp-artifact": "^0.1",
     "express": "^4.17.1",

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 const _ = require('lodash'),
       fs = require('fs'),
       tmp = require('tmp'),
@@ -91,10 +93,12 @@ describe("Canvas", ()=>{
       expect(c.width).toBe(W)
       expect(c.height).toBe(789)
 
+      // @ts-expect-error
       c = new Canvas('garbage', NaN)
       expect(c.width).toBe(W)
       expect(c.height).toBe(H)
-
+      
+      // @ts-expect-error
       c = new Canvas(false, {})
       expect(c.width).toBe(W)
       expect(c.height).toBe(H)
@@ -267,7 +271,7 @@ describe("Canvas", ()=>{
     })
 
     test("image Buffers", async () => {
-      for (ext of ["png", "jpg", "pdf", "svg"]){
+      for (let ext of ["png", "jpg", "pdf", "svg"]){
         // use extension to specify type
         let path = `${TMP}/output.${ext}`
         let buf = await canvas.toBuffer(ext)
@@ -289,7 +293,7 @@ describe("Canvas", ()=>{
     })
 
     test("data URLs", async () => {
-      for (ext in MIME){
+      for (let ext in MIME){
         let magic = MAGIC[ext],
             mime = MIME[ext],
             [extURL, mimeURL] = await Promise.all([
@@ -435,7 +439,7 @@ describe("Canvas", ()=>{
     })
 
     test("image Buffers", () => {
-      for (ext of ["png", "jpg", "pdf", "svg"]){
+      for (let ext of ["png", "jpg", "pdf", "svg"]){
         // use extension to specify type
         let path = `${TMP}/output.${ext}`
         let buf = canvas.toBuffer(ext)
@@ -457,7 +461,7 @@ describe("Canvas", ()=>{
     })
 
     test("data URLs", () => {
-      for (ext in MIME){
+      for (let ext in MIME){
         let magic = MAGIC[ext],
             mime = MIME[ext],
             extURL = canvas.toDataURL(ext),

--- a/test/context2d.test.js
+++ b/test/context2d.test.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 "use strict"
 
 const _ = require('lodash'),
@@ -423,6 +425,7 @@ describe("Context2D", ()=>{
     })
 
     test("fillText()", () => {
+      /** @type {[args: any[], shouldDraw: boolean][]} */
       let argsets = [
         [['A', 10, 10], true],
         [['A', 10, 10, undefined], true],

--- a/test/media.test.js
+++ b/test/media.test.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 const _ = require('lodash'),
       fs = require('fs'),
       glob = require('glob').sync,

--- a/test/path2d.test.js
+++ b/test/path2d.test.js
@@ -60,7 +60,6 @@ describe("Path2D", ()=>{
 
       let clone = new Path2D()
       for (const [verb, ...pts] of p.edges){
-        // @ts-expect-error This is not possible to be done in a type-safe way in TypeScript (yet, at least)
         clone[verb](...pts)
       }
 

--- a/test/path2d.test.js
+++ b/test/path2d.test.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 const _ = require('lodash'),
       {Canvas, DOMMatrix, Path2D} = require('../lib');
 
@@ -58,6 +60,7 @@ describe("Path2D", ()=>{
 
       let clone = new Path2D()
       for (const [verb, ...pts] of p.edges){
+        // @ts-expect-error This is not possible to be done in a type-safe way in TypeScript (yet, at least)
         clone[verb](...pts)
       }
 
@@ -207,7 +210,7 @@ describe("Path2D", ()=>{
       expect(pixel(163, 100)).toEqual(CLEAR)
 
       // with ccw enabled
-      p2 = new Path2D()
+      let p2 = new Path2D()
       p2.ellipse(100,100, 100, 50, .25*Math.PI, 0, 1.5*Math.PI, true)
       ctx.clearRect(0,0, WIDTH, HEIGHT)
       ctx.stroke(p2)

--- a/test/visual/tests.js
+++ b/test/visual/tests.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 var DOMMatrix
 var Image
 var imageSrc
@@ -10,6 +12,7 @@ if (typeof module !== 'undefined' && module.exports) {
   DOMMatrix = skCanvas.DOMMatrix
   imageSrc = function (filename) { return require('path').join(__dirname, '../assets', filename) }
 } else {
+  // @ts-expect-error We are creating a tests propery
   window.tests = tests
   Image = window.Image
   DOMMatrix = window.DOMMatrix


### PR DESCRIPTION
Closes #50 

I imported the types from `@types/skia-canvas`, and updated them to the current API.
I also added a `// @ts-check` annotation to the tests so they also work to check that the surface is correctly typed.