### PR TITLE
Use non-nested display lists

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1,17 +1,10 @@
 #![allow(non_snake_case)]
-#![allow(clippy::too_many_arguments)]
-use std::fs;
-use std::path::Path;
 use std::cell::RefCell;
 use neon::prelude::*;
-use rayon::prelude::*;
-use crc::{crc32, Hasher32};
-use skia_safe::{Rect, Matrix, Picture, Size, PictureRecorder,
-                Surface, EncodedImageFormat, Data, Color,
-                svg::{self, canvas::Flags}, pdf, Document};
 
 use crate::utils::*;
-use crate::context::{BoxedContext2D};
+use crate::context::BoxedContext2D;
+use crate::context::page::{Page, write_sequence, write_pdf};
 
 pub type BoxedCanvas = JsBox<RefCell<Canvas>>;
 impl Finalize for Canvas {}
@@ -28,176 +21,6 @@ impl Canvas{
   }
 }
 
-//
-// -- File I/O ------------------------------------------------------------------------------------
-//
-
-pub struct Page{
-  pub layers: Vec<Picture>,
-  pub bounds: Rect,
-}
-
-impl Page{
-
-  pub fn get_picture(&self) -> Option<Picture> {
-    let mut compositor = PictureRecorder::new();
-    compositor.begin_recording(self.bounds, None);
-    if let Some(output) = compositor.recording_canvas() {
-      for pict in self.layers.iter(){
-        output.draw_picture(pict, None, None);
-      }
-    }
-    compositor.finish_recording_as_picture(Some(&self.bounds))
-  }
-
-  fn encoded_as(&self, format:&str, quality:f32, density:f32, outline:bool, matte:Option<Color>) -> Result<Data, String> {
-    let picture = self.get_picture().ok_or("Could not generate an image")?;
-
-    if self.bounds.is_empty(){
-      Err("Width and height must be non-zero to generate an image".to_string())
-    }else{
-      let img_dims = self.bounds.size();
-      let img_format = match format {
-        "jpg" | "jpeg" => Some(EncodedImageFormat::JPEG),
-        "png" => Some(EncodedImageFormat::PNG),
-        _ => None
-      };
-
-      if let Some(img_format) = img_format{
-        let img_scale = Matrix::scale((density, density));
-        let img_dims = Size::new(img_dims.width * density, img_dims.height * density).to_floor();
-        if let Some(mut surface) = Surface::new_raster_n32_premul(img_dims){
-          surface
-            .canvas()
-            .clear(matte.unwrap_or(Color::TRANSPARENT))
-            .set_matrix(&img_scale.into())
-            .draw_picture(&picture, None, None);
-          surface
-            .image_snapshot()
-            .encode_to_data_with_quality(img_format, (quality*100.0) as i32)
-            .map(|data| with_dpi(data, img_format, density))
-            .ok_or(format!("Could not encode as {}", format))
-        }else{
-          Err("Could not allocate new bitmap".to_string())
-        }
-      }else if format == "pdf"{
-        let mut document = pdf_document(quality, density).begin_page(img_dims, None);
-        let canvas = document.canvas();
-        canvas.draw_picture(&picture, None, None);
-        Ok(document.end_page().close())
-      }else if format == "svg"{
-        let flags = outline.then(|| Flags::CONVERT_TEXT_TO_PATHS);
-        let mut canvas = svg::Canvas::new(Rect::from_size(img_dims), flags);
-        canvas.draw_picture(&picture, None, None);
-        Ok(canvas.end())
-      }else{
-        Err(format!("Unsupported file format {}", format))
-      }
-
-    }
-
-  }
-
-  fn write(&self, filename: &str, file_format:&str, quality:f32, density:f32, outline:bool, matte:Option<Color>) -> Result<(), String> {
-    let path = Path::new(&filename);
-    let data = self.encoded_as(file_format, quality, density, outline, matte)?;
-    fs::write(path, data.as_bytes()).map_err(|why|
-      format!("{}: \"{}\"", why, path.display())
-    )
-  }
-
-  fn append_to(&self, doc:Document) -> Result<Document, String>{
-    if !self.bounds.is_empty(){
-      let mut doc = doc.begin_page(self.bounds.size(), None);
-      let canvas = doc.canvas();
-      if let Some(picture) = self.get_picture(){
-        canvas.draw_picture(&picture, None, None);
-      }
-      Ok(doc.end_page())
-    }else{
-      Err("Width and height must be non-zero to generate a PDF page".to_string())
-    }
-  }
-}
-
-//
-// PDF creation
-//
-
-pub fn pdf_document(quality:f32, density:f32) -> Document{
-  let mut meta = pdf::Metadata::default();
-  meta.producer = "Skia Canvas <https://github.com/samizdatco/skia-canvas>".to_string();
-  meta.encoding_quality = Some((quality*100.0) as i32);
-  meta.raster_dpi = Some(density * 72.0);
-  pdf::new_document(Some(&meta))
-}
-
-fn to_pdf(pages:&[Page], quality:f32, density:f32) -> Result<Data, String>{
-  pages
-    .iter()
-    .try_fold(pdf_document(quality, density), |doc, page| page.append_to(doc))
-    .map(|doc| doc.close())
-}
-
-fn write_pdf(path:&str, pages:&[Page], quality:f32, density:f32) -> Result<(), String>{
-  let path = Path::new(&path);
-  match to_pdf(pages, quality, density){
-    Ok(document) => fs::write(path, document.as_bytes()).map_err(|why|
-      format!("{}: \"{}\"", why, path.display())
-    ),
-    Err(msg) => Err(msg)
-  }
-}
-
-//
-// Raster graphics
-//
-
-fn write_sequence(pages:&[Page], pattern:&str, format:&str, padding:f32, quality:f32, density:f32, outline:bool, matte:Option<Color>) -> Result<(), String>{
-  let padding = match padding as i32{
-    -1 => (1.0 + (pages.len() as f32).log10().floor()) as usize,
-    pad => pad as usize
-  };
-
-  pages
-    .par_iter()
-    .enumerate()
-    .try_for_each(|(pp, page)|{
-      let folio = format!("{:0width$}", pp+1, width=padding);
-      let filename = pattern.replace("{}", folio.as_str());
-      page.write(&filename, format, quality, density, outline, matte)
-    })
-}
-
-fn with_dpi(data:Data, format:EncodedImageFormat, density:f32) -> Data{
-  if density as u32 == 1 { return data }
-
-  let mut bytes = data.as_bytes().to_vec();
-  match format{
-    EncodedImageFormat::JPEG => {
-      let [l, r] = (72 * density as u16).to_be_bytes();
-      bytes.splice(13..18, [1, l, r, l, r].iter().cloned());
-      Data::new_copy(&bytes)
-    }
-    EncodedImageFormat::PNG => {
-      let mut digest = crc32::Digest::new(crc32::IEEE);
-      let [a, b, c, d] = ((72.0 * density * 39.3701) as u32).to_be_bytes();
-      let phys = vec![
-        b'p', b'H', b'Y', b's',
-        a, b, c, d, // x-dpi
-        a, b, c, d, // y-dpi
-        1, // dots per meter
-      ];
-      digest.write(&phys);
-
-      let length = 9u32.to_be_bytes().to_vec();
-      let checksum = digest.sum32().to_be_bytes().to_vec();
-      bytes.splice(33..33, [length, phys, checksum].concat());
-      Data::new_copy(&bytes)
-    }
-    _ => data
-  }
-}
 
 use neon::result::Throw;
 fn pages_arg(cx: &mut FunctionContext, idx: i32) -> Result<Vec<Page>, Throw> {
@@ -274,7 +97,7 @@ pub fn toBuffer(mut cx: FunctionContext) -> JsResult<JsUndefined> {
   rayon::spawn(move || {
     let encoded = {
       if file_format=="pdf" && pages.len() > 1 {
-        to_pdf(&pages, quality, density)
+        Page::to_pdf(&pages, quality, density)
       }else{
         pages[0].encoded_as(&file_format, quality, density, outline, matte)
       }
@@ -320,7 +143,7 @@ pub fn toBufferSync(mut cx: FunctionContext) -> JsResult<JsValue> {
 
     let encoded = {
       if file_format=="pdf" && pages.len() > 1 {
-        to_pdf(&pages, quality, density)
+        Page::to_pdf(&pages, quality, density)
       }else{
         pages[0].encoded_as(&file_format, quality, density, outline, matte)
       }

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -12,7 +12,7 @@ use skia_safe::{Rect, Matrix, Path as SkPath, Picture, Size,
                 svg::{self, canvas::Flags}, Document};
 
 use crate::utils::*;
-use crate::context::{BoxedContext2D, DrawList};
+use crate::context::{BoxedContext2D, Recorder};
 
 pub type BoxedCanvas = JsBox<RefCell<Canvas>>;
 impl Finalize for Canvas {}
@@ -34,7 +34,7 @@ impl Canvas{
 //
 
 pub struct Page{
-  pub draw_list: Arc<Mutex<DrawList>>,
+  pub recorder: Arc<Mutex<Recorder>>,
   pub bounds: Rect,
   pub clip: SkPath,
   pub matrix: Matrix,
@@ -46,7 +46,7 @@ unsafe impl Sync for Page{}
 impl Page{
 
   fn get_picture(&self) -> Option<Picture> {
-    let draw_list = Arc::clone(&self.draw_list);
+    let draw_list = Arc::clone(&self.recorder);
     let mut draw_list = draw_list.lock().unwrap();
     draw_list.get_picture(&self.matrix, &self.clip, Some(&self.bounds))
   }

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -39,7 +39,7 @@ pub struct Page{
 
 impl Page{
 
-  fn get_picture(&self) -> Option<Picture> {
+  pub fn get_picture(&self) -> Option<Picture> {
     let mut compositor = PictureRecorder::new();
     compositor.begin_recording(self.bounds, None);
     if let Some(output) = compositor.recording_canvas() {

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -121,6 +121,18 @@ impl Page{
   }
 }
 
+//
+// PDF creation
+//
+
+pub fn pdf_document(quality:f32, density:f32) -> Document{
+  let mut meta = pdf::Metadata::default();
+  meta.producer = "Skia Canvas <https://github.com/samizdatco/skia-canvas>".to_string();
+  meta.encoding_quality = Some((quality*100.0) as i32);
+  meta.raster_dpi = Some(density * 72.0);
+  pdf::new_document(Some(&meta))
+}
+
 fn to_pdf(pages:&[Page], quality:f32, density:f32) -> Result<Data, String>{
   pages
     .iter()
@@ -137,6 +149,10 @@ fn write_pdf(path:&str, pages:&[Page], quality:f32, density:f32) -> Result<(), S
     Err(msg) => Err(msg)
   }
 }
+
+//
+// Raster graphics
+//
 
 fn write_sequence(pages:&[Page], pattern:&str, format:&str, padding:f32, quality:f32, density:f32, outline:bool, matte:Option<Color>) -> Result<(), String>{
   let padding = match padding as i32{

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -37,9 +37,6 @@ pub struct Page{
   pub bounds: Rect,
 }
 
-unsafe impl Send for Page{}
-unsafe impl Sync for Page{}
-
 impl Page{
 
   fn get_picture(&self) -> Option<Picture> {

--- a/src/context/api.rs
+++ b/src/context/api.rs
@@ -651,7 +651,7 @@ pub fn drawCanvas(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     Some((src, dst)) => {
       let pict = {
         let mut ctx = context.borrow_mut();
-        ctx.get_picture(None)
+        ctx.get_picture()
       };
 
       let mut this = this.borrow_mut();

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -537,10 +537,8 @@ impl Context2D{
     recorder.get_page()
   }
 
-  pub fn get_picture(&mut self, cull: Option<&Rect>) -> Option<Picture> {
-    let recorder = Arc::clone(&self.recorder);
-    let mut recorder = recorder.lock().unwrap();
-    recorder.get_page().get_picture()
+  pub fn get_picture(&mut self) -> Option<Picture> {
+    self.get_page().get_picture()
   }
 
   pub fn get_pixels(&mut self, buffer: &mut [u8], origin: impl Into<IPoint>, size: impl Into<ISize>){
@@ -548,7 +546,7 @@ impl Context2D{
     let size = size.into();
     let info = ImageInfo::new(size, ColorType::RGBA8888, AlphaType::Unpremul, None);
 
-    if let Some(pict) = self.get_picture(None) {
+    if let Some(pict) = self.get_picture() {
       if let Some(mut bitmap_surface) = Surface::new_raster_n32_premul(size){
         let shift = Matrix::translate((-origin.x as f32, -origin.y as f32));
         bitmap_surface.canvas().draw_picture(&pict, Some(&shift), None);

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -181,7 +181,7 @@ impl Context2D{
     where F:FnOnce(MutexGuard<PageRecorder>)
   {
     let recorder = Arc::clone(&self.recorder);
-    let mut recorder = recorder.lock().unwrap();
+    let recorder = recorder.lock().unwrap();
     f(recorder);
   }
 
@@ -305,7 +305,7 @@ impl Context2D{
     });
     path.set_fill_type(rule.unwrap_or(FillType::Winding));
 
-    let mut paint = self.paint_for(style);
+    let paint = self.paint_for(style);
     let texture = self.state.texture(style);
 
     self.render_to_canvas(&paint, |canvas, paint| {
@@ -386,7 +386,7 @@ impl Context2D{
     let mut paint = self.state.paint.clone();
     paint.set_color(self.color_with_alpha(&BLACK));
 
-    if let Some(mut drobble) = drobble.as_mut(){
+    if let Some(drobble) = drobble{
       self.push();
       self.update_canvas(|canvas| {
         let size = ISize::new(dst_rect.width() as i32, dst_rect.height() as i32);

--- a/src/context/page.rs
+++ b/src/context/page.rs
@@ -1,0 +1,258 @@
+use std::fs;
+use std::path::Path as FilePath;
+use rayon::prelude::*;
+use crc::{crc32, Hasher32};
+use skia_safe::{Size,
+                Surface, EncodedImageFormat, Data, Color,
+                svg::{self, canvas::Flags}, pdf, Document};
+
+
+use skia_safe::{Canvas as SkCanvas, Path, Matrix, Rect, ClipOp, PictureRecorder, Picture};
+
+pub struct PageRecorder{
+  current: PictureRecorder,
+  layers: Vec<Picture>,
+  bounds: Rect,
+  matrix: Matrix,
+  clip: Path,
+  changed: bool,
+}
+
+impl PageRecorder{
+  pub fn new(bounds:Rect) -> Self {
+    let mut rec = PictureRecorder::new();
+    rec.begin_recording(bounds, None);
+    rec.recording_canvas().unwrap().save(); // start at depth 2
+    PageRecorder{ current:rec, changed:true, layers:vec![], matrix:Matrix::default(), clip:Path::default(), bounds }
+  }
+
+  pub fn append<F>(&mut self, f:F)
+    where F:FnOnce(&mut SkCanvas)
+  {
+    if let Some(canvas) = self.current.recording_canvas() {
+      f(canvas);
+      self.changed = true;
+    }
+  }
+
+  pub fn set_bounds(&mut self, bounds:Rect){
+    *self = PageRecorder::new(bounds);
+  }
+
+  pub fn set_matrix(&mut self, matrix:Matrix){
+    self.matrix = matrix;
+    if let Some(canvas) = self.current.recording_canvas() {
+      canvas.set_matrix(&matrix.into());
+    }
+  }
+
+  pub fn set_clip(&mut self, clip:&Path){
+    self.clip = clip.clone();
+    if let Some(canvas) = self.current.recording_canvas() {
+      canvas.restore_to_count(1);
+      canvas.save();
+      canvas.set_matrix(&self.matrix.into());
+      if !clip.is_empty(){
+        canvas.clip_path(clip, ClipOp::Intersect, true /* antialias */);
+      }
+    }
+  }
+
+  pub fn get_page(&mut self) -> Page{
+    if self.changed {
+      // stop and restart the recorder while adding its content as a new layer
+      if let Some(palimpsest) = self.current.finish_recording_as_picture(Some(&self.bounds)) {
+        self.layers.push(palimpsest);
+      }
+      self.current.begin_recording(self.bounds, None);
+      self.changed = false;
+
+      // restore the ctm & clip state
+      if let Some(canvas) = self.current.recording_canvas() {
+        canvas.save();
+        canvas.concat(&self.matrix);
+        if !self.clip.is_empty(){
+          canvas.clip_path(&self.clip, ClipOp::Intersect, true /* antialias */);
+        }
+      }
+    }
+
+    Page{
+      layers: self.layers.clone(),
+      bounds: self.bounds,
+    }
+  }
+}
+
+
+//
+// -- File I/O ------------------------------------------------------------------------------------
+//
+
+pub struct Page{
+  pub layers: Vec<Picture>,
+  pub bounds: Rect,
+}
+
+impl Page{
+
+  pub fn get_picture(&self) -> Option<Picture> {
+    let mut compositor = PictureRecorder::new();
+    compositor.begin_recording(self.bounds, None);
+    if let Some(output) = compositor.recording_canvas() {
+      for pict in self.layers.iter(){
+        output.draw_picture(pict, None, None);
+      }
+    }
+    compositor.finish_recording_as_picture(Some(&self.bounds))
+  }
+
+  pub fn encoded_as(&self, format:&str, quality:f32, density:f32, outline:bool, matte:Option<Color>) -> Result<Data, String> {
+    let picture = self.get_picture().ok_or("Could not generate an image")?;
+
+    if self.bounds.is_empty(){
+      Err("Width and height must be non-zero to generate an image".to_string())
+    }else{
+      let img_dims = self.bounds.size();
+      let img_format = match format {
+        "jpg" | "jpeg" => Some(EncodedImageFormat::JPEG),
+        "png" => Some(EncodedImageFormat::PNG),
+        _ => None
+      };
+
+      if let Some(img_format) = img_format{
+        let img_scale = Matrix::scale((density, density));
+        let img_dims = Size::new(img_dims.width * density, img_dims.height * density).to_floor();
+        if let Some(mut surface) = Surface::new_raster_n32_premul(img_dims){
+          surface
+            .canvas()
+            .clear(matte.unwrap_or(Color::TRANSPARENT))
+            .set_matrix(&img_scale.into())
+            .draw_picture(&picture, None, None);
+          surface
+            .image_snapshot()
+            .encode_to_data_with_quality(img_format, (quality*100.0) as i32)
+            .map(|data| with_dpi(data, img_format, density))
+            .ok_or(format!("Could not encode as {}", format))
+        }else{
+          Err("Could not allocate new bitmap".to_string())
+        }
+      }else if format == "pdf"{
+        let mut document = pdf_document(quality, density).begin_page(img_dims, None);
+        let canvas = document.canvas();
+        canvas.draw_picture(&picture, None, None);
+        Ok(document.end_page().close())
+      }else if format == "svg"{
+        let flags = outline.then(|| Flags::CONVERT_TEXT_TO_PATHS);
+        let mut canvas = svg::Canvas::new(Rect::from_size(img_dims), flags);
+        canvas.draw_picture(&picture, None, None);
+        Ok(canvas.end())
+      }else{
+        Err(format!("Unsupported file format {}", format))
+      }
+
+    }
+
+  }
+
+  pub fn write(&self, filename: &str, file_format:&str, quality:f32, density:f32, outline:bool, matte:Option<Color>) -> Result<(), String> {
+    let path = FilePath::new(&filename);
+    let data = self.encoded_as(file_format, quality, density, outline, matte)?;
+    fs::write(path, data.as_bytes()).map_err(|why|
+      format!("{}: \"{}\"", why, path.display())
+    )
+  }
+
+  fn append_to(&self, doc:Document) -> Result<Document, String>{
+    if !self.bounds.is_empty(){
+      let mut doc = doc.begin_page(self.bounds.size(), None);
+      let canvas = doc.canvas();
+      if let Some(picture) = self.get_picture(){
+        canvas.draw_picture(&picture, None, None);
+      }
+      Ok(doc.end_page())
+    }else{
+      Err("Width and height must be non-zero to generate a PDF page".to_string())
+    }
+  }
+
+  pub fn to_pdf(pages:&[Page], quality:f32, density:f32) -> Result<Data, String>{
+    pages
+      .iter()
+      .try_fold(pdf_document(quality, density), |doc, page| page.append_to(doc))
+      .map(|doc| doc.close())
+  }
+}
+
+//
+// PDF creation
+//
+
+pub fn pdf_document(quality:f32, density:f32) -> Document{
+  let mut meta = pdf::Metadata::default();
+  meta.producer = "Skia Canvas <https://github.com/samizdatco/skia-canvas>".to_string();
+  meta.encoding_quality = Some((quality*100.0) as i32);
+  meta.raster_dpi = Some(density * 72.0);
+  pdf::new_document(Some(&meta))
+}
+
+pub fn write_pdf(path:&str, pages:&[Page], quality:f32, density:f32) -> Result<(), String>{
+  let path = FilePath::new(&path);
+  match Page::to_pdf(pages, quality, density){
+    Ok(document) => fs::write(path, document.as_bytes()).map_err(|why|
+      format!("{}: \"{}\"", why, path.display())
+    ),
+    Err(msg) => Err(msg)
+  }
+}
+
+//
+// Raster graphics
+//
+
+#[allow(clippy::too_many_arguments)]
+pub fn write_sequence(pages:&[Page], pattern:&str, format:&str, padding:f32, quality:f32, density:f32, outline:bool, matte:Option<Color>) -> Result<(), String>{
+  let padding = match padding as i32{
+    -1 => (1.0 + (pages.len() as f32).log10().floor()) as usize,
+    pad => pad as usize
+  };
+
+  pages
+    .par_iter()
+    .enumerate()
+    .try_for_each(|(pp, page)|{
+      let folio = format!("{:0width$}", pp+1, width=padding);
+      let filename = pattern.replace("{}", folio.as_str());
+      page.write(&filename, format, quality, density, outline, matte)
+    })
+}
+
+fn with_dpi(data:Data, format:EncodedImageFormat, density:f32) -> Data{
+  if density as u32 == 1 { return data }
+
+  let mut bytes = data.as_bytes().to_vec();
+  match format{
+    EncodedImageFormat::JPEG => {
+      let [l, r] = (72 * density as u16).to_be_bytes();
+      bytes.splice(13..18, [1, l, r, l, r].iter().cloned());
+      Data::new_copy(&bytes)
+    }
+    EncodedImageFormat::PNG => {
+      let mut digest = crc32::Digest::new(crc32::IEEE);
+      let [a, b, c, d] = ((72.0 * density * 39.3701) as u32).to_be_bytes();
+      let phys = vec![
+        b'p', b'H', b'Y', b's',
+        a, b, c, d, // x-dpi
+        a, b, c, d, // y-dpi
+        1, // dots per meter
+      ];
+      digest.write(&phys);
+
+      let length = 9u32.to_be_bytes().to_vec();
+      let checksum = digest.sum32().to_be_bytes().to_vec();
+      bytes.splice(33..33, [length, phys, checksum].concat());
+      Data::new_copy(&bytes)
+    }
+    _ => data
+  }
+}

--- a/src/context/page.rs
+++ b/src/context/page.rs
@@ -2,12 +2,9 @@ use std::fs;
 use std::path::Path as FilePath;
 use rayon::prelude::*;
 use crc::{crc32, Hasher32};
-use skia_safe::{Size,
-                Surface, EncodedImageFormat, Data, Color,
+use skia_safe::{Canvas as SkCanvas, Path, Matrix, Rect, ClipOp, Size, Data, Color,
+                PictureRecorder, Picture, Surface, EncodedImageFormat,
                 svg::{self, canvas::Flags}, pdf, Document};
-
-
-use skia_safe::{Canvas as SkCanvas, Path, Matrix, Rect, ClipOp, PictureRecorder, Picture};
 
 pub struct PageRecorder{
   current: PictureRecorder,
@@ -23,7 +20,7 @@ impl PageRecorder{
     let mut rec = PictureRecorder::new();
     rec.begin_recording(bounds, None);
     rec.recording_canvas().unwrap().save(); // start at depth 2
-    PageRecorder{ current:rec, changed:true, layers:vec![], matrix:Matrix::default(), clip:Path::default(), bounds }
+    PageRecorder{ current:rec, changed:false, layers:vec![], matrix:Matrix::default(), clip:Path::default(), bounds }
   }
 
   pub fn append<F>(&mut self, f:F)

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -96,7 +96,7 @@ pub fn from_canvas(mut cx: FunctionContext) -> JsResult<BoxedCanvasPattern> {
     let dims = ctx.bounds.size();
     let stamp = Stamp{
       image:None,
-      pict:ctx.get_picture(None),
+      pict:ctx.get_picture(),
       dims,
       repeat,
       matrix:Matrix::new_identity()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -713,17 +713,3 @@ pub fn fit_bounds(width: f32, height: f32, src: Rect, dst: Rect) -> (Rect, Rect)
 
   (src, dst)
 }
-
-//
-// PDF creation
-//
-
-use skia_safe::{pdf, Document};
-
-pub fn pdf_document(quality:f32, density:f32) -> Document{
-  let mut meta = pdf::Metadata::default();
-  meta.producer = "Skia Canvas <https://github.com/samizdatco/skia-canvas>".to_string();
-  meta.encoding_quality = Some((quality*100.0) as i32);
-  meta.raster_dpi = Some(density * 72.0);
-  pdf::new_document(Some(&meta))
-}


### PR DESCRIPTION
The previous approach to making `PictureRecorder` restartable was to begin each recording with a `draw_picture` of the previous recording. This means an additional layer of nested picture-drawing each time the recorder is paused and restarted. It appears that deallocating those nested pictures happens recursively leading to a [stack overflow](https://github.com/rust-skia/rust-skia/issues/597) once the references get deep enough.

This patch flattens things out by storing a Vec of `Picture`s which is appended to each time the recorder is restarted. The layers are re-combined when a picture is generated, but during normal drawing the current recorder only contains drawing commands issued since the last 'snapshot' moment.

Fixes #49

To Do:
  - [x] convert the `Page` struct to work with just the layers rather than sharing a reference to the recorder
  - [x] only add a new layer if visible changes have been made to the recording canvas (i.e., not just state changes)

