### PR TITLE
Support GL and Vulkan backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ash"
+version = "0.35.2+1.2.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f6a491bcad4563b355ac2bb6e3f09d5e1c5d628710c7156e901dad0c416075e"
+dependencies = [
+ "libloading 0.7.3",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,6 +1588,7 @@ dependencies = [
 name = "skia-canvas"
 version = "0.9.29"
 dependencies = [
+ "ash",
  "crc",
  "css-color",
  "gl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ rayon = "^1.5"
 gl = "0.14.0"
 surfman = "0.4.3"
 
+ash = "0.35"
+
+
 [dependencies.neon]
 version = "0.9.1"
 default-features = false
@@ -26,4 +29,4 @@ features = ["napi-6", "channel-api"]
 
 [dependencies.skia-safe]
 version = "0.46.0"
-features = ["textlayout", "gl"]
+features = ["textlayout", "gl", "vulkan"]

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -55,6 +55,7 @@ export class Canvas {
   getContext(type?: "2d"): CanvasRenderingContext2D
   newPage(width?: number, height?: number): CanvasRenderingContext2D
   readonly pages: CanvasRenderingContext2D[]
+  gpuSupport(): string
 
   saveAs(filename: string, options?: SaveOptions): Promise<void>
   toBuffer(format: ExportFormat, options?: RenderOptions): Promise<Buffer>

--- a/lib/index.js
+++ b/lib/index.js
@@ -119,6 +119,10 @@ class Canvas extends RustClass{
     return (kind=="2d") ? Canvas.contexts.get(this)[0] || this.newPage() : null
   }
 
+  gpuSupport(){
+    return this.ƒ('gpuSupport')
+  }
+
   get width(){ return this.prop('width') }
   set width(w){
     this.prop('width', (typeof w=='number' && !Number.isNaN(w) && w>=0) ? w : 300)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "cargo-cp-artifact -nc lib/v6/index.node -- cargo build --message-format=json-render-diagnostics",
-    "install": "npm run build -- --release",
+    "install": "npm run build -- --release || true",
     "package": "node-pre-gyp package",
     "upload": "node-pre-gyp publish",
     "test": "jest"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "cargo-cp-artifact -nc lib/v6/index.node -- cargo build --message-format=json-render-diagnostics",
-    "install": "node-pre-gyp install || npm run build -- --release",
+    "install": "npm run build -- --release",
     "package": "node-pre-gyp package",
     "upload": "node-pre-gyp publish",
     "test": "jest"

--- a/src/context/page.rs
+++ b/src/context/page.rs
@@ -188,8 +188,6 @@ impl Page{
       };
 
       if let Some(img_format) = img_format{
-        gl_init();
-        let mut gl_context = DirectContext::new_gl(None, None).unwrap();
         let img_scale = Matrix::scale((density, density));
         let img_dims = Size::new(img_dims.width * density, img_dims.height * density).to_floor();
         let img_info = ImageInfo::new_n32_premul(img_dims, None);

--- a/src/context/page.rs
+++ b/src/context/page.rs
@@ -8,12 +8,12 @@ use skia_safe::{Canvas as SkCanvas, Path, Matrix, Rect, ClipOp, Size, Data, Colo
                 svg::{self, canvas::Flags}, pdf, Document, ImageInfo, Budgeted,
                 gpu::{SurfaceOrigin, DirectContext},
                 image::BitDepth};
-use surfman::{Device, Context, Connection, ContextAttributeFlags, ContextAttributes, GLApi, GLVersion};
 
 use crc::{Crc, CRC_32_ISO_HDLC};
 const CRC32: Crc<u32> = Crc::<u32>::new(&CRC_32_ISO_HDLC);
 
 use crate::context::BoxedContext2D;
+use crate::gpu::get_surface;
 
 //
 // Deferred canvas (records drawing commands for later replay on an output surface)
@@ -107,49 +107,6 @@ impl PageRecorder{
 // Image generator for a single drawing context
 //
 
-use std::cell::RefCell;
-use crate::init_gpu::get_vulkan_context;
-thread_local!(static GL_CONTEXT: RefCell<Option<GLContext>> = RefCell::new(None));
-
-fn gl_init(){
-  GL_CONTEXT.with(|cell| {
-    let mut local_ctx = cell.borrow_mut();
-    if local_ctx.is_none(){
-      local_ctx.replace(GLContext::new());
-    }
-  });
-}
-
-struct GLContext {
-  device:Device,
-  context:Context
-}
-
-impl GLContext {
-  pub fn new() -> Self{
-    let connection = Connection::new().unwrap();
-    let adapter = connection.create_hardware_adapter().unwrap();
-    let mut device = connection.create_device(&adapter).unwrap();
-    let context_attributes = ContextAttributes {
-      version: GLVersion::new(3, 3),
-      flags: ContextAttributeFlags::empty(),
-    };
-    let context_descriptor = device
-        .create_context_descriptor(&context_attributes)
-        .unwrap();
-    let mut context = device.create_context(&context_descriptor, None).unwrap();
-    device.make_context_current(&context).unwrap();
-    gl::load_with(|symbol_name| device.get_proc_address(&context, symbol_name));
-
-    GLContext{device, context}
-  }
-}
-
-impl Drop for GLContext {
-  fn drop(&mut self) {
-    self.device.destroy_context(&mut self.context).unwrap();
-  }
-}
 pub struct Page{
   pub layers: Vec<Picture>,
   pub bounds: Rect,
@@ -170,11 +127,6 @@ impl Page{
   }
 
   pub fn encoded_as(&self, format:&str, quality:f32, density:f32, outline:bool, matte:Option<Color>) -> Result<Data, String> {
-    self.gl_encoded_as(&format, quality, density, outline, matte)
-    // self.cpu_encoded_as(&format, quality, density, outline, matte)
-  }
-
-  pub fn gl_encoded_as(&self, format:&str, quality:f32, density:f32, outline:bool, matte:Option<Color>) -> Result<Data, String> {
     let picture = self.get_picture(matte).ok_or("Could not generate an image")?;
 
     if self.bounds.is_empty(){
@@ -192,15 +144,7 @@ impl Page{
         let img_dims = Size::new(img_dims.width * density, img_dims.height * density).to_floor();
         let img_info = ImageInfo::new_n32_premul(img_dims, None);
 
-        let mut surface = Surface::new_render_target(
-          &mut get_vulkan_context(),
-          Budgeted::Yes,
-          &img_info,
-          Some(4),
-          SurfaceOrigin::BottomLeft,
-          None,
-          true,
-        );
+        let mut surface = get_surface(&img_info);
 
         if let Some(mut surface) = surface{
           surface
@@ -229,52 +173,9 @@ impl Page{
       }else{
         Err(format!("Unsupported file format {}", format))
       }
-
     }
-
   }
 
-  pub fn cpu_encoded_as(&self, format:&str, quality:f32, density:f32, outline:bool, matte:Option<Color>) -> Result<Data, String> {
-    let picture = self.get_picture(matte).ok_or("Could not generate an image")?;
-
-    if self.bounds.is_empty(){
-      Err("Width and height must be non-zero to generate an image".to_string())
-    }else{
-      let img_dims = self.bounds.size();
-      let img_format = match format {
-        "jpg" | "jpeg" => Some(EncodedImageFormat::JPEG),
-        "png" => Some(EncodedImageFormat::PNG),
-        _ => None
-      };
-
-      if let Some(img_format) = img_format{
-        let img_scale = Matrix::scale((density, density));
-        let img_dims = Size::new(img_dims.width * density, img_dims.height * density).to_floor();
-        if let Some(img) = SkImage::from_picture(picture, img_dims, Some(&img_scale), None, BitDepth::U8, Some(ColorSpace::new_srgb())){
-          img
-            .encode_to_data_with_quality(img_format, (quality*100.0) as i32)
-            .map(|data| with_dpi(data, img_format, density))
-            .ok_or(format!("Could not encode as {}", format))
-        }else{
-          Err("Could not allocate new bitmap".to_string())
-        }
-      }else if format == "pdf"{
-        let mut document = pdf_document(quality, density).begin_page(img_dims, None);
-        let canvas = document.canvas();
-        canvas.draw_picture(&picture, None, None);
-        Ok(document.end_page().close())
-      }else if format == "svg"{
-        let flags = outline.then(|| Flags::CONVERT_TEXT_TO_PATHS);
-        let mut canvas = svg::Canvas::new(Rect::from_size(img_dims), flags);
-        canvas.draw_picture(&picture, None, None);
-        Ok(canvas.end())
-      }else{
-        Err(format!("Unsupported file format {}", format))
-      }
-
-    }
-
-  }
 
   pub fn write(&self, filename: &str, file_format:&str, quality:f32, density:f32, outline:bool, matte:Option<Color>) -> Result<(), String> {
     let path = FilePath::new(&filename);

--- a/src/context/page.rs
+++ b/src/context/page.rs
@@ -108,6 +108,7 @@ impl PageRecorder{
 //
 
 use std::cell::RefCell;
+use crate::init_gpu::get_vulkan_context;
 thread_local!(static GL_CONTEXT: RefCell<Option<GLContext>> = RefCell::new(None));
 
 fn gl_init(){
@@ -194,7 +195,7 @@ impl Page{
         let img_info = ImageInfo::new_n32_premul(img_dims, None);
 
         let mut surface = Surface::new_render_target(
-          &mut gl_context,
+          &mut get_vulkan_context(),
           Budgeted::Yes,
           &img_info,
           Some(4),

--- a/src/gpu/gl.rs
+++ b/src/gpu/gl.rs
@@ -1,0 +1,61 @@
+use surfman::{Device, Context, Connection, ContextAttributeFlags, ContextAttributes, GLVersion};
+use std::cell::RefCell;
+use skia_safe::gpu::DirectContext;
+
+thread_local!(static GL_CONTEXT: RefCell<Option<GLContext>> = RefCell::new(None));
+
+fn gl_init() -> bool {
+    GL_CONTEXT.with(|cell| {
+        let mut local_ctx = cell.borrow_mut();
+        if local_ctx.is_none(){
+            if let Some(ctx) = GLContext::new() {
+                local_ctx.replace(ctx);
+                true
+            } else {
+                false
+            }
+        } else {
+            true
+        }
+    })
+}
+
+pub fn gl_supported() -> bool {
+    gl_init()
+}
+
+pub fn get_gl_context() -> DirectContext {
+    gl_init();
+    DirectContext::new_gl(None, None).expect("Failed to create GL context")
+}
+
+struct GLContext {
+    device:Device,
+    context:Context
+}
+
+impl GLContext {
+    pub fn new() -> Option<Self> {
+        let connection = Connection::new().ok()?;
+        let adapter = connection.create_hardware_adapter().ok()?;
+        let mut device = connection.create_device(&adapter).ok()?;
+        let context_attributes = ContextAttributes {
+            version: GLVersion::new(3, 3),
+            flags: ContextAttributeFlags::empty(),
+        };
+        let context_descriptor = device
+            .create_context_descriptor(&context_attributes)
+            .ok()?;
+        let context = device.create_context(&context_descriptor, None).ok()?;
+        device.make_context_current(&context).ok()?;
+        gl::load_with(|symbol_name| device.get_proc_address(&context, symbol_name));
+
+        Some(GLContext{device, context})
+    }
+}
+
+impl Drop for GLContext {
+    fn drop(&mut self) {
+        self.device.destroy_context(&mut self.context).unwrap();
+    }
+}

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1,0 +1,46 @@
+use neon::context::{Context, FunctionContext};
+use neon::result::JsResult;
+use neon::types::JsString;
+use skia_safe::gpu::{DirectContext, SurfaceOrigin};
+use skia_safe::{Budgeted, ImageInfo, Surface};
+use crate::gpu::gl::{get_gl_context, gl_supported};
+use crate::gpu::vulkan::{get_vulkan_context, vulkan_supported};
+
+mod vulkan;
+mod gl;
+
+pub fn gpu_support(mut cx: FunctionContext) -> JsResult<JsString> {
+    Ok(if vulkan_supported() {
+        cx.string("vulkan")
+    } else if gl_supported() {
+        cx.string("gl")
+    } else {
+        cx.string("none")
+    })
+}
+
+fn get_direct_context() -> Option<DirectContext> {
+    if vulkan_supported() {
+        Some(get_vulkan_context())
+    } else if gl_supported() {
+        Some(get_gl_context())
+    } else {
+        None
+    }
+}
+
+pub fn get_surface(image_info: &ImageInfo) -> Option<Surface> {
+    if let Some(mut context) = get_direct_context() {
+        Surface::new_render_target(
+            &mut context,
+            Budgeted::Yes,
+            image_info,
+            Some(4),
+            SurfaceOrigin::BottomLeft,
+            None,
+            true,
+        )
+    } else {
+        Surface::new_raster(image_info, None, None)
+    }
+}

--- a/src/init_gpu.rs
+++ b/src/init_gpu.rs
@@ -1,0 +1,230 @@
+use std::ptr;
+use std::cell::RefCell;
+use std::ffi::CString;
+use std::os::raw;
+
+use ash::{Entry, Instance, vk};
+use ash::vk::Handle;
+use skia_safe::gpu;
+use skia_safe::gpu::DirectContext;
+
+thread_local!(static GL_CONTEXT: RefCell<Option<Vulkan>> = RefCell::new(None));
+
+
+fn vulkan_init() {
+    GL_CONTEXT.with(|cell| {
+        let mut local_ctx = cell.borrow_mut();
+        if local_ctx.is_none() {
+            local_ctx.replace(Vulkan::new());
+        }
+    })
+}
+
+pub fn get_vulkan_context() -> DirectContext {
+    vulkan_init();
+    GL_CONTEXT.with(|cell| {
+        let local_ctx = cell.borrow();
+        local_ctx.as_ref().unwrap().context.clone()
+    })
+}
+
+pub struct Vulkan {
+    context: gpu::DirectContext,
+    ash_graphics: AshGraphics,
+}
+
+impl Vulkan {
+    fn new() -> Self {
+        let ash_graphics = unsafe { AshGraphics::new("skia-canvas") };
+        let context = {
+            let get_proc = |of| unsafe {
+                match ash_graphics.get_proc(of) {
+                    Some(f) => f as _,
+                    None => {
+                        println!("resolve of {} failed", of.name().to_str().unwrap());
+                        ptr::null()
+                    }
+                }
+            };
+
+            let backend_context = unsafe {
+                gpu::vk::BackendContext::new(
+                    ash_graphics.instance.handle().as_raw() as _,
+                    ash_graphics.physical_device.as_raw() as _,
+                    ash_graphics.device.handle().as_raw() as _,
+                    (
+                        ash_graphics.queue_and_index.0.as_raw() as _,
+                        ash_graphics.queue_and_index.1,
+                    ),
+                    &get_proc,
+                )
+            };
+
+            gpu::DirectContext::new_vulkan(&backend_context, None).unwrap()
+        };
+
+        Self {
+            context,
+            ash_graphics,
+        }
+    }
+}
+
+
+pub struct AshGraphics {
+    pub entry: Entry,
+    pub instance: Instance,
+    pub physical_device: vk::PhysicalDevice,
+    pub device: ash::Device,
+    pub queue_and_index: (vk::Queue, usize),
+}
+
+impl Drop for AshGraphics {
+    fn drop(&mut self) {
+        unsafe {
+            self.device.device_wait_idle().unwrap();
+            self.device.destroy_device(None);
+            self.instance.destroy_instance(None);
+        }
+    }
+}
+
+// most code copied from here: https://github.com/MaikKlein/ash/blob/master/examples/src/lib.rs
+impl AshGraphics {
+    pub fn vulkan_version() -> Option<(usize, usize, usize)> {
+        let entry = unsafe { Entry::load() }.unwrap();
+
+        let detected_version = entry.try_enumerate_instance_version().unwrap_or(None);
+
+        detected_version.map(|ver| {
+            (
+                vk::api_version_major(ver).try_into().unwrap(),
+                vk::api_version_minor(ver).try_into().unwrap(),
+                vk::api_version_patch(ver).try_into().unwrap(),
+            )
+        })
+    }
+
+    pub unsafe fn new(app_name: &str) -> AshGraphics {
+        let entry = unsafe { Entry::load() }.unwrap();
+
+        let minimum_version = vk::make_api_version(0, 1, 0, 0);
+
+        let instance: Instance = {
+            let api_version = Self::vulkan_version()
+                .map(|(major, minor, patch)| {
+                    vk::make_api_version(
+                        0,
+                        major.try_into().unwrap(),
+                        minor.try_into().unwrap(),
+                        patch.try_into().unwrap(),
+                    )
+                })
+                .unwrap_or(minimum_version);
+
+            let app_name = CString::new(app_name).unwrap();
+            let layer_names: [&CString; 0] = []; // [CString::new("VK_LAYER_LUNARG_standard_validation").unwrap()];
+            let extension_names_raw = []; // extension_names();
+
+            let app_info = vk::ApplicationInfo::builder()
+                .application_name(&app_name)
+                .application_version(0)
+                .engine_name(&app_name)
+                .engine_version(0)
+                .api_version(api_version);
+
+            let layers_names_raw: Vec<*const raw::c_char> = layer_names
+                .iter()
+                .map(|raw_name| raw_name.as_ptr())
+                .collect();
+
+            let create_info = vk::InstanceCreateInfo::builder()
+                .application_info(&app_info)
+                .enabled_layer_names(&layers_names_raw)
+                .enabled_extension_names(&extension_names_raw);
+
+            entry
+                .create_instance(&create_info, None)
+                .expect("Failed to create a Vulkan instance.")
+        };
+
+        let (physical_device, queue_family_index) = {
+            let physical_devices = instance
+                .enumerate_physical_devices()
+                .expect("Failed to enumerate Vulkan physical devices.");
+
+            physical_devices
+                .iter()
+                .map(|physical_device| {
+                    instance
+                        .get_physical_device_queue_family_properties(*physical_device)
+                        .iter()
+                        .enumerate()
+                        .find_map(|(index, info)| {
+                            let supports_graphic =
+                                info.queue_flags.contains(vk::QueueFlags::GRAPHICS);
+                            if supports_graphic {
+                                Some((*physical_device, index))
+                            } else {
+                                None
+                            }
+                        })
+                })
+                .find_map(|v| v)
+                .expect("Failed to find a suitable Vulkan device.")
+        };
+
+        println!("Found device {:?}", physical_device);
+
+        let device: ash::Device = {
+            let features = vk::PhysicalDeviceFeatures::default();
+
+            let priorities = [1.0];
+
+            let queue_info = [vk::DeviceQueueCreateInfo::builder()
+                .queue_family_index(queue_family_index as _)
+                .queue_priorities(&priorities)
+                .build()];
+
+            let device_extension_names_raw = [];
+
+            let device_create_info = vk::DeviceCreateInfo::builder()
+                .queue_create_infos(&queue_info)
+                .enabled_extension_names(&device_extension_names_raw)
+                .enabled_features(&features);
+
+            instance
+                .create_device(physical_device, &device_create_info, None)
+                .unwrap()
+        };
+
+        println!("Created device");
+
+
+        let queue_index: usize = 0;
+        let queue: vk::Queue = device.get_device_queue(queue_family_index as _, queue_index as _);
+
+        println!("Got queue {:?}", queue);
+
+        AshGraphics {
+            queue_and_index: (queue, queue_index),
+            device,
+            physical_device,
+            instance,
+            entry,
+        }
+    }
+
+    pub unsafe fn get_proc(&self, of: gpu::vk::GetProcOf) -> Option<unsafe extern "system" fn()> {
+        match of {
+            gpu::vk::GetProcOf::Instance(instance, name) => {
+                let ash_instance = vk::Instance::from_raw(instance as _);
+                self.entry.get_instance_proc_addr(ash_instance, name)
+            }
+            gpu::vk::GetProcOf::Device(device, name) => {
+                let ash_device = vk::Device::from_raw(device as _);
+                self.instance.get_device_proc_addr(ash_device, name)
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ mod pattern;
 mod texture;
 mod typography;
 mod utils;
-mod init_gpu;
+mod gpu;
 
 use context::api as ctx;
 use typography::FontLibrary;
@@ -97,6 +97,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
   // -- Canvas ------------------------------------------------------------------------------------
 
   cx.export_function("Canvas_new", canvas::new)?;
+  cx.export_function("Canvas_gpuSupport", gpu::gpu_support)?;
   cx.export_function("Canvas_get_width", canvas::get_width)?;
   cx.export_function("Canvas_set_width", canvas::set_width)?;
   cx.export_function("Canvas_get_height", canvas::get_height)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod pattern;
 mod texture;
 mod typography;
 mod utils;
+mod init_gpu;
 
 use context::api as ctx;
 use typography::FontLibrary;


### PR DESCRIPTION
These changes allow for `DirectContext`s to be created with either OpenGl or Vulkan and moves the selection between the two into a new module at `src/gpu`. If neither GPU backend is available, it will use CPU rendering as a fallback. The selection is exposed in Javascript on the `Canvas` object through a new method called `gpuSupport()`.

It's unclear how large the performance benefits from GPU rendering are, but the output is *much* closer to that seen in browsers since the GPU pathway is what they actually use (meaning bugs like #88 that crop up in the CPU renderer frequently don't get noticed upstream).

---

Many thanks to @lucasmerlin for this fantastic work!