### PR TITLE
add basic webp support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ crossbeam = "0.8.2"
 once_cell = "1.13"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-skia-safe = { version = "0.52.0", features = ["textlayout"] }
+skia-safe = { version = "0.52.0", features = ["textlayout", "webp"] }
 
 # vulkan
 ash = { version = "0.37", optional = true }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -23,7 +23,7 @@ export class Image extends globalThis.Image {
 // Canvas
 //
 
-export type ExportFormat = "png" | "jpg" | "jpeg" | "pdf" | "svg";
+export type ExportFormat = "png" | "jpg" | "jpeg" | "webp" | "pdf" | "svg";
 
 export interface RenderOptions {
   /** Page to export: Defaults to 1 (i.e., first page) */

--- a/lib/io.js
+++ b/lib/io.js
@@ -20,11 +20,11 @@ class Format{
       toMime: this.toMime.bind(this),
       fromMime: this.fromMime.bind(this),
       expected: isWeb ? `"png", "jpg", or "webp"`
-                      : `"png", "jpg", "pdf", or "svg"`,
+                      : `"png", "jpg", "web", "pdf", or "svg"`,
       formats: isWeb ? {png, jpg, jpeg, webp}
-                     : {png, jpg, jpeg, pdf, svg},
+                     : {png, jpg, jpeg, webp, pdf, svg},
       mimes: isWeb ? {[png]: "png", [jpg]: "jpg", [webp]: "webp"}
-                   : {[png]: "png", [jpg]: "jpg", [pdf]: "pdf", [svg]: "svg"},
+                   : {[png]: "png", [jpg]: "jpg", [webp]: "webp", [pdf]: "pdf", [svg]: "svg"},
     })
   }
 

--- a/src/context/page.rs
+++ b/src/context/page.rs
@@ -140,6 +140,7 @@ impl Page{
       let img_format = match format {
         "jpg" | "jpeg" => Some(EncodedImageFormat::JPEG),
         "png" => Some(EncodedImageFormat::PNG),
+        "webp" => Some(EncodedImageFormat::WEBP),
         _ => None
       };
 


### PR DESCRIPTION
I couldn't find an existing issue or PR for `webp` support in the library, so I decided to tackle the task myself. It was really easy to add it — provided i didn't overlook anything. It is tested and working locally with both gpu (vulkan on linux) and cpu rendering.

It might need some extra handling for dpi scaling in https://github.com/samizdatco/skia-canvas/blob/main/src/context/page.rs, but I'm not too familiar with either this code-base or rust in general, so I'll let all of you — the maintainers — determine that.
