### PR TITLE
Remove $ from install command documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ In particular, Skia Canvas:
 
 If you’re running on a supported platform, installation should be as simple as:
 ```console
-$ npm install skia-canvas
+npm install skia-canvas
 ```
 
 This will download a pre-compiled library from the project’s most recent [release](https://github.com/samizdatco/skia-canvas/releases).


### PR DESCRIPTION
GitHub's markdown renderer helpfully provides a "click to copy" button for code blocks, as highlighted here:

![image](https://github.com/samizdatco/skia-canvas/assets/2487968/89666188-91f2-432b-b2aa-d04d8a6c8fe0)

However, the existing installation command includes a preceding `$ ` for stylistic purposes to imply that this command should be run in a terminal. If a user clicks the copy button and pastes directly to the CLI, the command will fail due to the `$ `:

<img width="313" alt="image" src="https://github.com/samizdatco/skia-canvas/assets/2487968/e2e92266-45de-48b5-be27-2d1a77d590d3">

This PR removes the stylistic `$ ` so that the copied install command is precisely `npm install skia-canvas` and will work as expected.
