### PR TITLE
EventEmitter intellisense/type safety

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -279,7 +279,59 @@ export type WindowOptions = {
   canvas?: Canvas
 }
 
-export class Window extends EventEmitter{
+type MouseEventProps = {
+  x: number;
+  y: number;
+  pageX: number;
+  pageY: number;
+  button: number;
+  ctrlKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+};
+type KeyboardEventProps = {
+  key: string;
+  code: number;
+  repeat: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+};
+type WindowEvents = {
+  mousedown: MouseEventProps;
+  mouseup: MouseEventProps;
+  mousemove: MouseEventProps;
+  keydown: KeyboardEventProps;
+  keyup: KeyboardEventProps;
+  input: {
+    value: string;
+    code: number;
+    ctrlKey: boolean;
+    altKey: boolean;
+    metaKey: boolean;
+    shiftKey: boolean;
+  };
+  wheel: { deltaX: number; deltaY: number };
+  fullscreen: { enabled: boolean };
+  move: { left: number; top: number };
+  resize: { height: number; width: number };
+  frame: { frame: number };
+  draw: { frame: number };
+  blur: {};
+  focus: {};
+  setup: {};
+};
+type WindowEventsMap = {
+  [EventName in keyof WindowEvents]: [
+    {
+      target: Window;
+      type: EventName;
+    } & WindowEvents[EventName]
+  ];
+};
+export class Window extends EventEmitter<WindowEventsMap>{
   constructor(width: number, height: number, options?: WindowOptions)
   constructor(options?: WindowOptions)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skia-canvas",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "skia-canvas",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@types/jest": "^28.1.6",
-        "@types/node": "^18.6.1",
+        "@types/node": "^18.19.59",
         "express": "^4.18.1",
         "jest": "^28.1.3",
         "lodash": "^4.17.21",
@@ -1131,10 +1131,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.1.tgz",
-      "integrity": "sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg==",
-      "dev": true
+      "version": "18.19.59",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.59.tgz",
+      "integrity": "sha512-vizm2EqwV/7Zay+A6J3tGl9Lhr7CjZe2HmWS988sefiEmsyP9CeXEleho6i4hJk/8UtZAo0bWN4QPZZr83RxvQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.6.3",
@@ -4803,6 +4806,12 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -5873,10 +5882,13 @@
       }
     },
     "@types/node": {
-      "version": "18.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.1.tgz",
-      "integrity": "sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg==",
-      "dev": true
+      "version": "18.19.59",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.59.tgz",
+      "integrity": "sha512-vizm2EqwV/7Zay+A6J3tGl9Lhr7CjZe2HmWS988sefiEmsyP9CeXEleho6i4hJk/8UtZAo0bWN4QPZZr83RxvQ==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/prettier": {
       "version": "2.6.3",
@@ -8606,6 +8618,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "unpipe": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/jest": "^28.1.6",
-    "@types/node": "^18.6.1",
+    "@types/node": "^18.19.59",
     "express": "^4.18.1",
     "jest": "^28.1.3",
     "lodash": "^4.17.21",


### PR DESCRIPTION
The current type declaration does not provide intellisense to the EventEmitter methods of Window:
![image](https://github.com/user-attachments/assets/4101cf3b-57bb-442e-a630-ed26545e4501)

Which is quite annoying because the only way to know the parameter for a specific event would be to log them beforehand.
Through some logging and typescript gymnastic I've created a mapped type for every suppoerted event, so that the EventEmitter methods will suggest the event types and correctly infer the respective callbacks arguments:
![Screenshot 2024-10-21 020634](https://github.com/user-attachments/assets/70a8a1cd-3279-41f6-bd0f-82bfbf083cc6)
![Screenshot 2024-10-21 020737](https://github.com/user-attachments/assets/232c467b-169f-44d0-a089-2465054970c6)
![Screenshot 2024-10-21 020611](https://github.com/user-attachments/assets/727abc6a-d26c-4ca0-bef5-84a2dc7db5e5)
