### PR TITLE
Fix exception in `canvas::draw_path()` when trying to draw a path with an invalid transform matrix.

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -310,7 +310,7 @@ impl Context2D{
   pub fn draw_path(&mut self, path:Option<Path>, style:PaintStyle, rule:Option<FillType>){
     let mut path = path.unwrap_or_else(|| {
       // the current path has already incorporated its transform state
-      let inverse = self.state.matrix.invert().unwrap();
+      let inverse = self.state.matrix.invert().unwrap_or_default();
       self.path.with_transform(&inverse)
     });
     path.set_fill_type(rule.unwrap_or(FillType::Winding));


### PR DESCRIPTION
Fixes #149 

E.g.
```js
ctx.setTransform(0, 0, 0, 0, 154, 271.601);
ctx.beginPath();
ctx.arc(0, 0, 2, 0, 6.283185307179586);
ctx.closePath();
ctx.fill();   // <= internal error in Neon module: called `Option::unwrap()` on a `None` value
```


Related to: #172