### PR TITLE
Fix issue in `Path2D::add_ellipse()` where trying to draw a complete circle from certain angle combinations produced nothing.

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -32,6 +32,35 @@ impl Path2D{
     }
   }
 
+  fn _ellipse_helper(&mut self, oval:Rect, start_angle:f32, end_angle:f32)
+  {
+    // Based off of Chrome's implementation in
+    // https://cs.chromium.org/chromium/src/third_party/blink/renderer/platform/graphics/path.cc
+    // of note, can't use addArc or addOval because they close the arc, which
+    // the spec says not to do (unless the user explicitly calls closePath).
+    // This throws off points being in/out of the arc.
+
+    // rounding degrees to 4 decimals eliminates ambiguity from f32 imprecision dealing with radians
+    let mut sweep_deg = (to_degrees(end_angle - start_angle) * 10000.0).round() / 10000.0;
+    let mut start_deg = (to_degrees(start_angle) * 10000.0).round() / 10000.0;
+
+    // draw in 2 180 degree segments because trying to draw all 360 degrees at once draws nothing.
+    if sweep_deg >= 359.9999  {
+      self.path.arc_to(oval, start_deg, 180.0, false);
+      self.path.arc_to(oval, start_deg + 180.0, 180.0, false);
+      return;
+    }
+
+    if sweep_deg <= -359.9999 {
+      self.path.arc_to(oval, start_deg, -180.0, false);
+      self.path.arc_to(oval, start_deg - 180.0, -180.0, false);
+      return;
+    }
+
+    // Draw incomplete (< 360 degrees) ellipses here.
+    self.path.arc_to(oval, start_deg, sweep_deg, false);
+  }
+
   pub fn add_ellipse(&mut self, origin:impl Into<Point>, radii:impl Into<Point>, rotation: f32, start_angle:f32, end_angle:f32, ccw:bool){
     let Point{x, y} = origin.into();
     let Point{x:x_radius, y:y_radius} = radii.into();
@@ -46,23 +75,21 @@ impl Path2D{
     let start_angle = new_start_angle;
     let mut end_angle = end_angle + delta;
 
-    // Based off of AdjustEndAngle in Chrome.
-    if !ccw && (end_angle - start_angle) >= tau {
-      end_angle = start_angle + tau; // Draw complete ellipse
-    } else if ccw && (start_angle - end_angle) >= tau {
-      end_angle = start_angle - tau; // Draw complete ellipse
-    } else if !ccw && start_angle > end_angle {
+    // Originally based off of AdjustEndAngle in Chrome, but does not limit to 360 degree sweep.
+    if !ccw && start_angle > end_angle {
       end_angle = start_angle + (tau - (start_angle - end_angle) % tau);
-    } else if ccw && start_angle < end_angle {
+    }
+    else if ccw && start_angle < end_angle {
       end_angle = start_angle - (tau - (end_angle - start_angle) % tau);
     }
 
-    // Based off of Chrome's implementation in
-    // https://cs.chromium.org/chromium/src/third_party/blink/renderer/platform/graphics/path.cc
-    // of note, can't use addArc or addOval because they close the arc, which
-    // the spec says not to do (unless the user explicitly calls closePath).
-    // This throws off points being in/out of the arc.
     let oval = Rect::new(x - x_radius, y - y_radius, x + x_radius, y + y_radius);
+
+    if almost_equal(rotation, 0.0) {
+      self._ellipse_helper(oval, start_angle, end_angle);
+      return;
+    }
+
     let mut rotated = Matrix::new_identity();
     rotated
       .pre_translate((x, y))
@@ -71,19 +98,7 @@ impl Path2D{
     let unrotated = rotated.invert().unwrap();
 
     self.path.transform(&unrotated);
-
-    // draw in 2 180 degree segments because trying to draw all 360 degrees at once
-    // draws nothing.
-    let sweep_deg = to_degrees(end_angle - start_angle);
-    let start_deg = to_degrees(start_angle);
-    if almost_equal(sweep_deg.abs(), 360.0) {
-      let half_sweep = sweep_deg/2.0;
-      self.path.arc_to(oval, start_deg, half_sweep, false);
-      self.path.arc_to(oval, start_deg + half_sweep, half_sweep, false);
-    }else{
-      self.path.arc_to(oval, start_deg, sweep_deg, false);
-    }
-
+    self._ellipse_helper(oval, start_angle, end_angle);
     self.path.transform(&rotated);
   }
 }

--- a/test/path2d.test.js
+++ b/test/path2d.test.js
@@ -243,6 +243,27 @@ describe("Path2D", ()=>{
       expect(pixel(127, 175)).toEqual(CLEAR)
       expect(pixel(130, 60)).toEqual(CLEAR)
       expect(pixel(163, 100)).toEqual(BLACK)
+
+      // full ellipse from offset angles, clockwise
+      p.ellipse(100,100, 100, 50, .25*Math.PI, -.5*Math.PI, 1.5*Math.PI, false)
+      ctx.lineWidth = 5
+      ctx.strokeStyle = 'black'
+      ctx.stroke(p)
+
+      expect(pixel(127, 175)).toEqual(BLACK)
+      expect(pixel(130, 60)).toEqual(BLACK)
+      expect(pixel(163, 100)).toEqual(BLACK)
+
+      // full ellipse from offset angles, CCW
+      p.ellipse(100,100, 100, 50, .25*Math.PI, -.5*Math.PI, 1.5*Math.PI, true)
+      ctx.lineWidth = 5
+      ctx.strokeStyle = 'black'
+      ctx.stroke(p)
+
+      expect(pixel(127, 175)).toEqual(BLACK)
+      expect(pixel(130, 60)).toEqual(BLACK)
+      expect(pixel(163, 100)).toEqual(BLACK)
+
     })
   })
 

--- a/test/visual/tests.js
+++ b/test/visual/tests.js
@@ -5,6 +5,8 @@ var Image
 var imageSrc
 var tests = {}
 
+const D2R = Math.PI / 180;
+
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = tests
   let skCanvas = require('../../lib')
@@ -237,6 +239,22 @@ tests["ellipse() 5"] = function (ctx) {
   ctx.closePath()
   ctx.fillStyle="#5a0e3e"
   ctx.fill()
+}
+
+tests["ellipse() full circle from offset angles CW"] = function (ctx) {
+  ctx.beginPath()
+  ctx.ellipse(100,100, 100, 50, 45 * D2R, -90 * D2R, 270 * D2R, false)
+  ctx.lineWidth = 5
+  ctx.strokeStyle = 'black'
+  ctx.stroke()
+}
+
+tests["ellipse() full circle from offset angles CCW"] = function (ctx) {
+  ctx.beginPath()
+  ctx.ellipse(100,100, 100, 50, 45 * D2R, -90 * D2R, 270 * D2R, true)
+  ctx.lineWidth = 5
+  ctx.strokeStyle = 'black'
+  ctx.stroke()
 }
 
 tests['bezierCurveTo()'] = function (ctx) {


### PR DESCRIPTION
For example, drawing a full circle ellipse from -90° to 270° clockwise produced nothing.
```js
tests["ellipse() full circle from offset angles CW"] = function (ctx) {
  const p = new Path2D()
  p.ellipse(100,100, 100, 50, .25*Math.PI, -.5*Math.PI, 1.5*Math.PI, false)
  ctx.lineWidth = 5
  ctx.strokeStyle = 'black'
  ctx.stroke(p)
}
```
![path-ellipse-issue](https://github.com/user-attachments/assets/705222a2-cc4e-4efe-b1cb-6f0d7d31b0dc)

I actually had to dig into Chrome source to see how they do it because it seems like a Skia anomaly.

Now we get:
![path-ellipse-fix](https://github.com/user-attachments/assets/bf29e157-8d37-4a61-a938-1492acc0a582)


Related to: #172