### PR TITLE
Fix clipping not being applied to the source in `drawCanvas()` 9-argument version

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -404,7 +404,6 @@ impl Context2D{
 
   pub fn draw_picture(&mut self, picture:&Option<Picture>, src_rect:&Rect, dst_rect:&Rect){
     let paint = self.paint_for_image();
-    let size = ISize::new(dst_rect.width() as i32, dst_rect.height() as i32);
     let mag = Point::new(dst_rect.width()/src_rect.width(), dst_rect.height()/src_rect.height());
     let mut matrix = Matrix::new_identity();
     matrix.pre_scale( (mag.x, mag.y), None )
@@ -418,7 +417,10 @@ impl Context2D{
           (Some(BlendMode::SrcOver), 255, None) => None,
           _ => Some(paint)
         };
-        canvas.draw_picture(picture, Some(&matrix), paint);
+        canvas.save();
+        canvas.clip_rect(dst_rect, ClipOp::Intersect, true);
+        canvas.draw_picture(&picture, Some(&matrix), paint);
+        canvas.restore();
       });
     }
   }

--- a/test/context2d.test.js
+++ b/test/context2d.test.js
@@ -380,12 +380,12 @@ describe("Context2D", ()=>{
       expect(pixel(10, 10)).toEqual([0, 162, 213, 245])
     })
 
-    test('shadow', async() => {      
+    test('shadow', async() => {
       const sin = Math.sin(1.15*Math.PI)
-      const cos = Math.cos(1.15*Math.PI)  
+      const cos = Math.cos(1.15*Math.PI)
       ctx.translate(150, 150)
       ctx.transform(cos, sin, -sin, cos, 0, 0)
-      
+
       ctx.shadowColor = '#000'
       ctx.shadowBlur = 5
       ctx.shadowOffsetX = 10
@@ -792,6 +792,13 @@ describe("Context2D", ()=>{
       expect(pixel(WIDTH*.25, HEIGHT/2)).toEqual(GREEN)
       expect(pixel(WIDTH*.75, HEIGHT/2)).toEqual(GREEN)
       expect(pixel(WIDTH/2, HEIGHT/2)).toEqual(CLEAR)
+
+      ctx.clearRect(0,0,WIDTH,HEIGHT)
+      ctx.drawCanvas(srcCanvas, 1,1,2,2, 0,0,2,2)
+      expect(pixel(0, 0)).toEqual(CLEAR)
+      expect(pixel(0, 1)).toEqual(GREEN)
+      expect(pixel(1, 0)).toEqual(GREEN)
+      expect(pixel(1, 1)).toEqual(GREEN)
 
       let image = await loadAsset('checkers.png')
       expect( () => ctx.drawCanvas(image, 0, 0) ).not.toThrow()

--- a/test/visual/tests.js
+++ b/test/visual/tests.js
@@ -2,6 +2,7 @@
 
 var DOMMatrix
 var Image
+var Canvas
 var imageSrc
 var tests = {}
 
@@ -12,6 +13,7 @@ if (typeof module !== 'undefined' && module.exports) {
   let skCanvas = require('../../lib')
   Image = skCanvas.Image
   DOMMatrix = skCanvas.DOMMatrix
+  Canvas = skCanvas.Canvas
   imageSrc = function (filename) { return require('path').join(__dirname, '../assets', filename) }
 } else {
   // @ts-expect-error We are creating a tests propery
@@ -2151,6 +2153,21 @@ tests['drawImage(img,sx,sy,sw,sh,x,y,w,h)'] = function (ctx, done) {
     done(null)
   }
   img.onerror = done
+  img.src = imageSrc('state.png')
+}
+
+tests['drawCanvas(img,sx,sy,sw,sh,x,y,w,h)'] = function (ctx, done) {
+  if (!Canvas) {
+    return tests['drawImage(img,sx,sy,sw,sh,x,y,w,h)'](ctx, done)
+  }
+  var img = new Image()
+  img.onload = function () {
+    const srcCtx = new Canvas(200,200).getContext('2d');
+    srcCtx.drawImage(img, 0, 0);
+    ctx.drawCanvas(srcCtx.canvas, 13, 13, 45, 45, 25, 25, img.width / 2, img.height / 2)
+    done(null)
+  }
+  img.onerror = (e) => { console.log(e); done(e); }
   img.src = imageSrc('state.png')
 }
 


### PR DESCRIPTION
The `drawCanvas()` test below should look like the `drawImage()` one above it. Same source image, same coordinates used, but source image first drawn another canvas at full size.

```js
// tests['drawImage ....
  img.onload = function () {
    ctx.drawImage(img, 13, 13, 45, 45, 25, 25, img.width / 2, img.height / 2)
  }

// tests['drawCanvas ....
  img.onload = function () {
    const ctx2 = new Canvas(200,200).getContext('2d');
    ctx2.drawImage(img, 0, 0);
    ctx.drawCanvas(ctx2.canvas, 13, 13, 45, 45, 25, 25, img.width / 2, img.height / 2)
  }
```

![image](https://github.com/user-attachments/assets/4470e8a4-45a6-44ac-a8e0-c0b8c07fbf1f)

The canvas' `Picture` can't be clipped, as far as I can tell, and there's no `SkCanvs.draw_picture()` version that takes a clip, like with `draw_image_rect_..()`, so I clipped the destination canvas instead.

![image](https://github.com/user-attachments/assets/ed05ac69-b5f5-483a-bfaf-fd25c7f359e0)

This came up while I was working on SVG rendering and was doing a final check, expecting the current `Content2D.draw_picture()` to take care of things once given a Picture... then was surprised. Luckily thought to test with `drawCanvas()` first before assuming it had anything to do with SVG specifically.