### PR TITLE
Adjust JS `Image` sizing properties to be more inline with standard.

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -11,17 +11,8 @@ export class CanvasTexture {}
 //
 
 
-/** Options for `loadImage` and `Image()` constructor. */
-export interface ImageOptions {
-  /** Image width */
-  width?: number
-  /** Image height */
-  height?: number
-}
-
 export class Image {
   constructor(width?: number, height?: number)
-  constructor(options: ImageOptions)
   get src(): string
   set src(src: string | Buffer)
   get width(): number
@@ -32,9 +23,11 @@ export class Image {
   get naturalHeight(): number
   onload: ((this: Image, image: Image) => any) | null;
   onerror: ((this: Image, error: Error) => any) | null;
+  complete: boolean
+  decode(): Promise<Image>
 }
 
-export function loadImage(src: string | Buffer, options?: ImageOptions): Promise<Image>
+export function loadImage(src: string | Buffer, width?: number, height?: number): Promise<Image>
 
 export class ImageData extends globalThis.ImageData {}
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -10,12 +10,33 @@ export class CanvasTexture {}
 // Images
 //
 
-export function loadImage(src: string | Buffer): Promise<Image>
-export class ImageData extends globalThis.ImageData {}
-export class Image extends globalThis.Image {
+
+/** Options for `loadImage` and `Image()` constructor. */
+export interface ImageOptions {
+  /** Image width */
+  width?: number
+  /** Image height */
+  height?: number
+}
+
+export class Image {
+  constructor(width?: number, height?: number)
+  constructor(options: ImageOptions)
   get src(): string
   set src(src: string | Buffer)
+  get width(): number
+  set width(w:number)
+  get height(): number
+  set height(h:number)
+  get naturalWidth(): number
+  get naturalHeight(): number
+  onload: ((this: Image, image: Image) => any) | null;
+  onerror: ((this: Image, error: Error) => any) | null;
 }
+
+export function loadImage(src: string | Buffer, options?: ImageOptions): Promise<Image>
+
+export class ImageData extends globalThis.ImageData {}
 
 //
 // DOMMatrix

--- a/lib/index.js
+++ b/lib/index.js
@@ -838,6 +838,7 @@ class FontLibrary extends RustClass {
 }
 
 class Image extends RustClass {
+  #fetch
   #type // for future use by the SVG loader…
 
   constructor(width, height) {
@@ -861,10 +862,13 @@ class Image extends RustClass {
     const noop = () => {},
           onload = img => fetch.emit('ok', img),
           onerror = err => fetch.emit('err', err),
-          passthrough = fn => arg => { (fn||noop)(arg); delete this._fetch }
+          passthrough = fn => arg => { 
+            (fn||noop)(arg); 
+            this.#fetch = null; 
+          }
 
-    if (this._fetch) this._fetch.removeAllListeners()
-    let fetch = this._fetch = new EventEmitter()
+    if (this.#fetch) this.#fetch.removeAllListeners()
+    let fetch = this.#fetch = new EventEmitter()
         .once('ok', passthrough((this.onload || noop).bind(this)))
         .once('err', passthrough((this.onerror || noop).bind(this)))
 
@@ -906,7 +910,7 @@ class Image extends RustClass {
   }
 
   decode(){
-    return this._fetch ? new Promise((res, rej) => this._fetch.once('ok', res).once('err', rej) )
+    return this.#fetch ? new Promise((res, rej) => this.#fetch.once('ok', res).once('err', rej) )
          : this.complete ? Promise.resolve(this)
          : Promise.reject(new Error("Missing Source URL"))
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -880,7 +880,7 @@ class Image extends RustClass {
       return
     } else if (/^\s*data:/.test(src)) {
       // data URI
-      let [header, mime, enc] = src.match(/^\s*data:(?<mime>[^;]*);(?:charset=)?(?<enc>[^,]*),/) || []
+      let [header, mime, enc] = src.slice(0, 40).match(/^\s*data:(?<mime>[^;]*);(?:charset=)?(?<enc>[^,]*),/) || []
       if (!mime || !enc){
         throw new Error(`Invalid data URI header`)
       }else{

--- a/lib/index.js
+++ b/lib/index.js
@@ -838,24 +838,13 @@ class FontLibrary extends RustClass {
 }
 
 class Image extends RustClass {
-  #options
+  #type // for future use by the SVG loader…
 
-  constructor(...args) {
+  constructor(width, height) {
     super(Image).alloc()
-    this.#options = {}
 
-    if (typeof args[0] == 'number') {
-      this.width = args[0]
-      if (args.length > 1 && typeof args[1] == 'number')
-        this.height = args[1]
-    }
-    else if (typeof args[0] == 'object') {
-      Object.assign(this.#options, structuredClone(args[0]))
-      if (typeof this.#options.width == 'number')
-        this.width = this.#options.width
-      if (typeof this.#options.height == 'number')
-        this.height = this.#options.height
-    }
+    if (width!==undefined) this.width = width
+    if (height!==undefined) this.height = height
   }
 
   get complete(){      return this.prop('complete') }
@@ -1082,7 +1071,7 @@ class TextMetrics{
   }
 }
 
-const loadImage = (src, options = null) => Object.assign(new Image(options), {src}).decode()
+const loadImage = (src, width, height) => Object.assign(new Image(width, height), {src}).decode()
 
 module.exports = {
   Canvas, CanvasGradient, CanvasPattern, CanvasRenderingContext2D, CanvasTexture,

--- a/lib/index.js
+++ b/lib/index.js
@@ -853,9 +853,9 @@ class Image extends RustClass {
   get naturalWidth(){  return this.prop('naturalWidth') }
 
   get height(){ return this.prop('height') }
-  set height(height){  this.prop('height', height) }
+  set height(height){  this.prop('height', parseFloat(height)) }
   get width(){  return this.prop('width') }
-  set width(width){    this.prop('width', width) }
+  set width(width){    this.prop('width', parseFloat(width)) }
 
   get src(){    return this.prop('src') }
   set src(src){

--- a/lib/index.js
+++ b/lib/index.js
@@ -838,26 +838,48 @@ class FontLibrary extends RustClass {
 }
 
 class Image extends RustClass {
-  constructor(){
+  #options
+
+  constructor(...args) {
     super(Image).alloc()
+    this.#options = {}
+
+    if (typeof args[0] == 'number') {
+      this.width = args[0]
+      if (args.length > 1 && typeof args[1] == 'number')
+        this.height = args[1]
+    }
+    else if (typeof args[0] == 'object') {
+      Object.assign(this.#options, structuredClone(args[0]))
+      if (typeof this.#options.width == 'number')
+        this.width = this.#options.width
+      if (typeof this.#options.height == 'number')
+        this.height = this.#options.height
+    }
   }
 
-  get complete(){ return this.prop('complete') }
-  get height(){ return this.prop('height') }
-  get width(){ return this.prop('width') }
+  get complete(){      return this.prop('complete') }
+  get naturalHeight(){ return this.prop('naturalHeight') }
+  get naturalWidth(){  return this.prop('naturalWidth') }
 
-  get src(){ return this.prop('src') }
+  get height(){ return this.prop('height') }
+  set height(height){  this.prop('height', height) }
+  get width(){  return this.prop('width') }
+  set width(width){    this.prop('width', width) }
+
+  get src(){    return this.prop('src') }
   set src(src){
-    var noop = () => {},
-        onload = img => fetch.emit('ok', img),
-        onerror = err => fetch.emit('err', err),
-        passthrough = fn => arg => { (fn||noop)(arg); delete this._fetch },
-        data
+    const noop = () => {},
+          onload = img => fetch.emit('ok', img),
+          onerror = err => fetch.emit('err', err),
+          passthrough = fn => arg => { (fn||noop)(arg); delete this._fetch }
 
     if (this._fetch) this._fetch.removeAllListeners()
     let fetch = this._fetch = new EventEmitter()
         .once('ok', passthrough((this.onload || noop).bind(this)))
         .once('err', passthrough((this.onerror || noop).bind(this)))
+
+    let data;
 
     if (Buffer.isBuffer(src)){
       [data, src] = [src, '']
@@ -901,9 +923,9 @@ class Image extends RustClass {
   }
 
   [REPR](depth, options) {
-    let {width, height, complete, src} = this
+    let {width, height, naturalWidth, naturalHeight, complete, src} = this
     options.maxStringLength = src.match(/^data:/) ? 128 : Infinity;
-    return `Image ${inspect({width, height, complete, src}, options)}`
+    return `Image ${inspect({width, height, naturalWidth, naturalHeight, complete, src}, options)}`
   }
 }
 
@@ -1060,7 +1082,7 @@ class TextMetrics{
   }
 }
 
-const loadImage = src => Object.assign(new Image(), {src}).decode()
+const loadImage = (src, options = null) => Object.assign(new Image(options), {src}).decode()
 
 module.exports = {
   Canvas, CanvasGradient, CanvasPattern, CanvasRenderingContext2D, CanvasTexture,

--- a/lib/index.js
+++ b/lib/index.js
@@ -880,10 +880,13 @@ class Image extends RustClass {
       return
     } else if (/^\s*data:/.test(src)) {
       // data URI
-      let split = src.indexOf(','),
-          enc = src.lastIndexOf('base64', split) !== -1 ? 'base64' : 'utf8',
-          content = src.slice(split + 1);
-      data = Buffer.from(content, enc);
+      let [header, mime, enc] = src.match(/^\s*data:(?<mime>[^;]*);(?:charset=)?(?<enc>[^,]*),/) || []
+      if (!mime || !enc){
+        throw new Error(`Invalid data URI header`)
+      }else{
+        data = Buffer.from(src.slice(header.length), enc);
+        this.#type = mime
+      }
     } else if (/^\s*https?:\/\//.test(src)) {
       // remote URL
       get.concat(src, (err, res, data) => {

--- a/src/image.rs
+++ b/src/image.rs
@@ -14,7 +14,8 @@ impl Finalize for Image {}
 
 pub struct Image{
   src:String,
-  size:ISize,
+  width:Option<i32>,
+  height:Option<i32>,
   pub image:Option<SkImage>,
 }
 
@@ -33,15 +34,11 @@ impl Image{
   }
 
   pub fn size(&self) -> ISize {
-    let mut size = self.size.clone();
-    let img_size = self.image_size();
-    if size.width < 0 {
-      size.width = img_size.width;
+    let actual_size = self.image_size();
+    ISize{
+      width: self.width.unwrap_or(actual_size.width),
+      height: self.height.unwrap_or(actual_size.height),
     }
-    if size.height < 0 {
-      size.height = img_size.height;
-    }
-    size
   }
 
 }
@@ -52,9 +49,7 @@ impl Image{
 
 pub fn new(mut cx: FunctionContext) -> JsResult<BoxedImage> {
   let this = RefCell::new(Image{
-    src:"".to_string(),
-    size:ISize::new(-1,-1),
-    image:None,
+    image:None, width:None, height:None, src:"".to_string() 
   });
   Ok(cx.boxed(this))
 }
@@ -62,7 +57,6 @@ pub fn new(mut cx: FunctionContext) -> JsResult<BoxedImage> {
 pub fn get_src(mut cx: FunctionContext) -> JsResult<JsString> {
   let this = cx.argument::<BoxedImage>(0)?;
   let this = this.borrow();
-
   Ok(cx.string(&this.src))
 }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -89,9 +89,8 @@ pub fn get_width(mut cx: FunctionContext) -> JsResult<JsValue> {
 pub fn set_width(mut cx: FunctionContext) -> JsResult<JsUndefined> {
   let this = cx.argument::<BoxedImage>(0)?;
   let mut this = this.borrow_mut();
-  if let Some(num) = opt_float_arg(&mut cx, 1){
-    this.size.width = i32::max(0, num as i32);
-  }
+  let num = float_arg_or(&mut cx, 1, 0.0);
+  this.width = Some(num.max(0.0) as i32);
   Ok(cx.undefined())
 }
 
@@ -104,9 +103,8 @@ pub fn get_height(mut cx: FunctionContext) -> JsResult<JsValue> {
 pub fn set_height(mut cx: FunctionContext) -> JsResult<JsUndefined> {
   let this = cx.argument::<BoxedImage>(0)?;
   let mut this = this.borrow_mut();
-  if let Some(num) = opt_float_arg(&mut cx, 1){
-    this.size.height = i32::max(0, num as i32);
-  }
+  let num = float_arg_or(&mut cx, 1, 0.0);
+  this.height = Some(num.max(0.0) as i32);
   Ok(cx.undefined())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,11 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
   cx.export_function("Image_set_src", image::set_src)?;
   cx.export_function("Image_set_data", image::set_data)?;
   cx.export_function("Image_get_width", image::get_width)?;
+  cx.export_function("Image_set_width", image::set_width)?;
   cx.export_function("Image_get_height", image::get_height)?;
+  cx.export_function("Image_set_height", image::set_height)?;
+  cx.export_function("Image_get_naturalWidth", image::get_natural_width)?;
+  cx.export_function("Image_get_naturalHeight", image::get_natural_height)?;
   cx.export_function("Image_get_complete", image::get_complete)?;
 
   // -- Path2D ------------------------------------------------------------------------------------

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -63,7 +63,7 @@ pub fn from_image(mut cx: FunctionContext) -> JsResult<BoxedCanvasPattern> {
 
   if let Some(repeat) = to_repeat_mode(&repetition){
     let src = src.borrow();
-    let dims = src.size();
+    let dims = Size::from_isize(src.image_size());
     let stamp = Stamp{
       image:src.image.clone(),
       pict:None,

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -63,7 +63,7 @@ pub fn from_image(mut cx: FunctionContext) -> JsResult<BoxedCanvasPattern> {
 
   if let Some(repeat) = to_repeat_mode(&repetition){
     let src = src.borrow();
-    let dims = Size::from_isize(src.image_size());
+    let dims = src.image_size().into();
     let stamp = Stamp{
       image:src.image.clone(),
       pict:None,

--- a/test/media.test.js
+++ b/test/media.test.js
@@ -126,33 +126,58 @@ describe("Image", () => {
   })
 
   describe("can decode format", () => {
+    const asDataURI = path => {
+      let ext = path.split('.').at(-1),
+          mime = `image/${ext.replace('jpg', 'jpeg')}`,
+          content = fs.readFileSync(path).toString('base64')
+      return `data:${mime};base64,${content}`
+    }
+    
     test("PNG", () => {
       img.src = FORMAT + '.png'
+      expect(img).toMatchObject(PARSED)
+
+      img.src = asDataURI(img.src)
       expect(img).toMatchObject(PARSED)
     })
 
     test("JPEG", () => {
       img.src = FORMAT + '.jpg'
       expect(img).toMatchObject(PARSED)
+
+      img.src = asDataURI(img.src)
+      expect(img).toMatchObject(PARSED)
     })
 
     test("GIF", () => {
       img.src = FORMAT + '.gif'
+      expect(img).toMatchObject(PARSED)
+
+      img.src = asDataURI(img.src)
       expect(img).toMatchObject(PARSED)
     })
 
     test("BMP", () => {
       img.src = FORMAT + '.bmp'
       expect(img).toMatchObject(PARSED)
+
+      img.src = asDataURI(img.src)
+      expect(img).toMatchObject(PARSED)
     })
 
     test("ICO", () => {
       img.src = FORMAT + '.ico'
       expect(img).toMatchObject(PARSED)
+
+      img.src = asDataURI(img.src)
+      expect(img).toMatchObject(PARSED)
     })
 
     test("WEBP", () => {
       img.src = FORMAT + '.webp'
+      expect(img).toMatchObject(PARSED)
+
+      img.src = asDataURI(img.src)
       expect(img).toMatchObject(PARSED)
     })
   })

--- a/test/media.test.js
+++ b/test/media.test.js
@@ -27,10 +27,10 @@ describe("Image", () => {
       URL = `https://${PATH}`,
       BUFFER = fs.readFileSync(PATH),
       DATA_URI = `data:image/png;base64,${BUFFER.toString('base64')}`,
-      FRESH = {complete:false, width:undefined, height:undefined},
-      LOADED = {complete:true, width:125, height:125},
+      FRESH = {complete:false, width:0, height:0, naturalWidth:0, naturalHeight:0},
+      LOADED = {complete:true, width:125, height:125, naturalWidth:125, naturalHeight:125},
       FORMAT = 'test/assets/image/format',
-      PARSED = {complete:true, width:60, height:60},
+      PARSED = {complete:true, width:60, height:60, naturalWidth:60, naturalHeight:60},
       img
 
   beforeEach(() => img = new Image() )
@@ -62,6 +62,13 @@ describe("Image", () => {
         done()
       }
       img.src = URL
+    })
+
+    test("set size vs natural size", () => {
+      img = new Image(50,50)
+      expect(img).toMatchObject({complete:false, width:50, height:50, naturalWidth:0, naturalHeight:0})
+      img.src = DATA_URI
+      expect(img).toMatchObject({complete:true, width:50, height:50, naturalWidth:125, naturalHeight:125})
     })
 
     test("loadImage call", async () => {
@@ -230,10 +237,10 @@ describe("FontLibrary", ()=>{
           name = "Monoton"
       expect(() => FontLibrary.use(woff)).not.toThrow()
       expect(FontLibrary.has(name)).toBe(true)
-  
+
       ctx.font = '256px Monoton'
       ctx.fillText('G', 128, 256)
-  
+
       // look for one of the gaps between the inline strokes of the G
       let bmp = ctx.getImageData(300, 172, 1, 1)
       expect(Array.from(bmp.data)).toEqual([0,0,0,0])

--- a/test/media.test.js
+++ b/test/media.test.js
@@ -64,13 +64,6 @@ describe("Image", () => {
       img.src = URL
     })
 
-    test("set size vs natural size", () => {
-      img = new Image(50,50)
-      expect(img).toMatchObject({complete:false, width:50, height:50, naturalWidth:0, naturalHeight:0})
-      img.src = DATA_URI
-      expect(img).toMatchObject({complete:true, width:50, height:50, naturalWidth:125, naturalHeight:125})
-    })
-
     test("loadImage call", async () => {
       expect(img).toMatchObject(FRESH)
 
@@ -161,6 +154,53 @@ describe("Image", () => {
     test("WEBP", () => {
       img.src = FORMAT + '.webp'
       expect(img).toMatchObject(PARSED)
+    })
+  })
+
+  describe("size can be", () => {
+    const sizeBefore = (width, height) => ({width, height, complete:false, naturalWidth:0, naturalHeight:0})
+    const sizeAfter = (width, height) => ({width, height, complete:true, naturalWidth:125, naturalHeight:125})
+    const compareSizes = (img, before, after) => {
+      expect(img).toMatchObject(before)
+      img.src = DATA_URI
+      expect(img).toMatchObject(after)
+    }
+
+    test("different from natural size", () => {
+      img = new Image(50, 50)
+      compareSizes(img, sizeBefore(50, 50), sizeAfter(50, 50))
+    })
+
+    test("set with just width or just height", () => {
+      // no custom size
+      img = new Image()
+      compareSizes(img, sizeBefore(0,0), sizeAfter(125, 125))
+
+      // just width
+      img = new Image(50)
+      compareSizes(img, sizeBefore(50, 0), sizeAfter(50, 125))
+
+      // just height
+      img = new Image(undefined, 50)
+      compareSizes(img, sizeBefore(0, 50), sizeAfter(125, 50))
+    })
+
+    test("set to NaN without error", () => {
+      img = new Image(NaN, NaN)
+      compareSizes(img, sizeBefore(0, 0), sizeAfter(0, 0))
+    })
+
+    test("set to non-numbers without error", () => {
+      img = new Image(25, 'frobozz')
+      compareSizes(img, sizeBefore(25, 0), sizeAfter(25, 0))
+
+      img = new Image({}, 25)
+      compareSizes(img, sizeBefore(0, 25), sizeAfter(0, 25))
+    })
+
+    test("set to non-positive/integer values", () => {
+      img = new Image(-1, 22.4)
+      compareSizes(img, sizeBefore(0, 22), sizeAfter(0, 22))
     })
   })
 })

--- a/test/visual/tests.js
+++ b/test/visual/tests.js
@@ -2112,7 +2112,27 @@ tests['drawImage(img) webp'] = function (ctx, done) {
 tests['drawImage(img,x,y)'] = function (ctx, done) {
   var img = new Image()
   img.onload = function () {
-    ctx.drawImage(img, 5, 25)
+    ctx.drawImage(img, 25, 25)
+    done(null)
+  }
+  img.onerror = done
+  img.src = imageSrc('state.png')
+}
+
+tests['drawImage(img,x,y) with Image(w,h)'] = function (ctx, done) {
+  var img = new Image(50,75)
+  img.onload = function () {
+    ctx.drawImage(this, 25, 25)
+    done(null)
+  }
+  img.onerror = done
+  img.src = imageSrc('state.png')
+}
+
+tests['drawImage(img,x,y,img.w,img.h) with Image(w,h)'] = function (ctx, done) {
+  var img = new Image(50,75)
+  img.onload = function () {
+    ctx.drawImage(this, 25, 25, this.width, this.height)
     done(null)
   }
   img.onerror = done


### PR DESCRIPTION
* allow specifying dimensions in constructor as arguments (`new image(w,h)`) or in options object;
* the `width` and `height` properties are now settable, and return the set size, if any, otherwise the actual image dimensions;
* added `naturalWidth` & `naturalHeight` read-only properties which always return actual image dimensions;
* added optional `options` argument to `loadImage()` which gets passed to `Image` constructor;
* updated TypeScript definitions and no longer inherit from global Image (which is an HTMLElement with many things our version is missing);
* added tests.