### PR TITLE
Fix generic fonts initialization when `FontCollection.use()` is called first before other fonts usage.

### DIFF
--- a/src/typography.rs
+++ b/src/typography.rs
@@ -463,42 +463,43 @@ impl FontLibrary{
   fn font_collection(&mut self) -> FontCollection{
     // lazily initialize font collection on first actual use
     if self.collection.is_none(){
-      // set up generic font family mappings
-      if self.generics.is_empty(){
-        let mut generics = vec![];
-        let mut font_stacks = HashMap::new();
-        font_stacks.insert("serif", vec!["Times", "Nimbus Roman", "Times New Roman", "Tinos", "Noto Serif", "Liberation Serif", "DejaVu Serif", "Source Serif Pro"]);
-        font_stacks.insert("sans-serif", vec!["Avenir Next", "Avenir", "Helvetica Neue", "Helvetica", "Arial Nova", "Arial", "Inter", "Arimo", "Roboto", "Noto Sans", "Liberation Sans", "DejaVu Sans", "Nimbus Sans", "Clear Sans", "Lato", "Cantarell", "Arimo", "Ubuntu"]);
-        font_stacks.insert("monospace", vec!["Cascadia Code", "Source Code Pro", "Menlo", "Consolas", "Monaco", "Liberation Mono", "Ubuntu Mono", "Roboto Mono", "Lucida Console", "Monaco", "Courier New", "Courier"]);
-        font_stacks.insert("system-ui", vec!["Helvetica Neue", "Ubuntu", "Segoe UI", "Fira Sans", "Roboto", "DroidSans", "Tahoma"]);
-        // see also: https://modernfontstacks.com | https://systemfontstack.com | https://www.ctrl.blog/entry/font-stack-text.html
+      self.rebuild_collection(); // assigns to self.collection
+    };
+    self.collection.as_ref().unwrap().clone()
+  }
 
-        // Set up mappings for generic font names based on the first match found on the system
-        for (generic_name, families) in font_stacks.into_iter() {
-          let best_match = families.iter().find_map(|fam| {
-            let mut style_set = self.mgr.match_family(fam);
-            match style_set.count() > 0{
-              true => Some(style_set),
-              false => None
-            }
-          });
+  fn ensure_generics(&mut self) {
+    // set up generic font family mappings
+    if self.generics.is_empty(){
+      let mut generics = vec![];
+      let mut font_stacks = HashMap::new();
+      font_stacks.insert("serif", vec!["Times", "Nimbus Roman", "Times New Roman", "Tinos", "Noto Serif", "Liberation Serif", "DejaVu Serif", "Source Serif Pro"]);
+      font_stacks.insert("sans-serif", vec!["Avenir Next", "Avenir", "Helvetica Neue", "Helvetica", "Arial Nova", "Arial", "Inter", "Arimo", "Roboto", "Noto Sans", "Liberation Sans", "DejaVu Sans", "Nimbus Sans", "Clear Sans", "Lato", "Cantarell", "Arimo", "Ubuntu"]);
+      font_stacks.insert("monospace", vec!["Cascadia Code", "Source Code Pro", "Menlo", "Consolas", "Monaco", "Liberation Mono", "Ubuntu Mono", "Roboto Mono", "Lucida Console", "Monaco", "Courier New", "Courier"]);
+      font_stacks.insert("system-ui", vec!["Helvetica Neue", "Ubuntu", "Segoe UI", "Fira Sans", "Roboto", "DroidSans", "Tahoma"]);
+      // see also: https://modernfontstacks.com | https://systemfontstack.com | https://www.ctrl.blog/entry/font-stack-text.html
 
-          let alias = Some(generic_name.to_string());
-          if let Some(mut style_set) = best_match{
-            for style_index in 0..style_set.count() {
-              if let Some(font) = style_set.new_typeface(style_index){
-                generics.push((font, alias.clone()));
-              }
+      // Set up mappings for generic font names based on the first match found on the system
+      for (generic_name, families) in font_stacks.into_iter() {
+        let best_match = families.iter().find_map(|fam| {
+          let mut style_set = self.mgr.match_family(fam);
+          match style_set.count() > 0{
+            true => Some(style_set),
+            false => None
+          }
+        });
+
+        let alias = Some(generic_name.to_string());
+        if let Some(mut style_set) = best_match{
+          for style_index in 0..style_set.count() {
+            if let Some(font) = style_set.new_typeface(style_index){
+              generics.push((font, alias.clone()));
             }
           }
         }
-        self.generics = generics;
       }
-
-      self.rebuild_collection(); // assigns to self.collection
-    };
-
-    self.collection.as_ref().unwrap().clone()
+      self.generics = generics;
+    }
   }
 
   pub fn font_mgr(&mut self) -> FontMgr {
@@ -610,6 +611,8 @@ impl FontLibrary{
 
   fn rebuild_collection(&mut self){
     let mut assets = TypefaceFontProvider::new();
+
+    self.ensure_generics();
     for (font, alias) in &self.generics {
       assets.register_typeface(font.clone(), alias.as_deref());
     }

--- a/src/typography.rs
+++ b/src/typography.rs
@@ -593,6 +593,9 @@ impl FontLibrary{
   }
 
   fn add_typeface(&mut self, font:Typeface, alias:Option<String>){
+    // make sure the collection & generics have been initialized before starting
+    self.font_collection();
+
     // replace any previously added font with the same metadata/alias
     if let Some(idx) = self.fonts.iter().position(|(old_font, old_alias)|
       match alias.is_some(){

--- a/test/visual/tests.js
+++ b/test/visual/tests.js
@@ -1378,6 +1378,54 @@ tests['font style variant weight size family'] = function (ctx) {
   ctx.fillText('normal normal normal 16px', 100, 100)
 }
 
+tests['generic font family monospace'] = function (ctx) {
+  ctx.strokeStyle = '#666'
+  ctx.strokeRect(0, 0, 200, 200)
+  ctx.lineTo(0, 100)
+  ctx.lineTo(200, 100)
+  ctx.stroke()
+
+  ctx.font = '22px monospace, "Times New Roman", "Times", serif'
+  ctx.textAlign = 'center'
+  ctx.fillText('monospace iWlx', 100, 100)
+}
+
+tests['generic font family fallback serif'] = function (ctx) {
+  ctx.strokeStyle = '#666'
+  ctx.strokeRect(0, 0, 200, 200)
+  ctx.lineTo(0, 100)
+  ctx.lineTo(200, 100)
+  ctx.stroke()
+
+  ctx.font = '24px None_suchFont, serif, Arial, monospace'
+  ctx.textAlign = 'center'
+  ctx.fillText('serif fallback', 100, 100)
+}
+
+tests['generic font family fallback sans-serif'] = function (ctx) {
+  ctx.strokeStyle = '#666'
+  ctx.strokeRect(0, 0, 200, 200)
+  ctx.lineTo(0, 100)
+  ctx.lineTo(200, 100)
+  ctx.stroke()
+
+  ctx.font = '24px None_suchFont, sans-serif, "Times New Roman", "Times", monospace'
+  ctx.textAlign = 'center'
+  ctx.fillText('sans-serif fallback', 100, 100)
+}
+
+tests['generic font family fallback system-ui'] = function (ctx) {
+  ctx.strokeStyle = '#666'
+  ctx.strokeRect(0, 0, 200, 200)
+  ctx.lineTo(0, 100)
+  ctx.lineTo(200, 100)
+  ctx.stroke()
+
+  ctx.font = '24px None_suchFont, system-ui, "Times New Roman", "Times", serif'
+  ctx.textAlign = 'center'
+  ctx.fillText('system-ui fallback', 100, 100)
+}
+
 // From https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalCompositeOperation
 const gco = [
   'source-over', 'source-in', 'source-out', 'source-atop',


### PR DESCRIPTION
The problem was that if `FontCollection.use()` was called before any other usage of `FontCollection` (like setting a font on a context), the stored `FontCollection.collection` was initialized w/out generics (and never initialized again, ofc).

I added tests, and there's one strange anomaly on my system, in the first new test for `monospace` type. If I put the name of another existing font _after_ the `monospace` font (as in the test), it gets used instead . But this only happens for `monospace` and not the others.  😕   (Though probably an unlikely use case.)

And 👍🏼  for adding the generics, pretty cool!