### PR TITLE
Fix: index.md's typo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ async function render(){
 render()
 
 // ...or save the file synchronously from the main thread
-canvas.saveAsSync("rainbox.pdf")
+canvas.saveAsSync("rainbox.png")
 ```
 
 ### Multi-page sequences


### PR DESCRIPTION
fix confusing mention of saving a canvas as pdf