### PR TITLE
define DOMRectInit (don't rely on ambient definition)

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -59,6 +59,13 @@ interface DOMRect extends DOMRectReadOnly {
   y: number;
 }
 
+interface DOMRectInit {
+  height?: number;
+  width?: number;
+  x?: number;
+  y?: number;
+}
+
 declare var DOMRect: {
   prototype: DOMRect;
   new(x?: number, y?: number, width?: number, height?: number): DOMRect;


### PR DESCRIPTION
Looks like this is the only one that was missed in 27815c1bcb9127692d420611d1d8c955208306d5

---

The error I'm seeing without these changes:

```
[0] node_modules/skia-canvas/lib/index.d.ts(66,20): error TS2552: Cannot find name 'DOMRectInit'. Did you mean 'DOMRectList'?
[0] node_modules/skia-canvas/lib/index.d.ts(105,20): error TS2552: Cannot find name 'DOMRectInit'. Did you mean 'DOMRectList'?
```

Probably something in your own `node_modules` is ambient-defining `DOMRectInit`. I haven't figured out how to properly test for this yet. It's a real pain.