### PR TITLE
Accept any `{x:number, y:number}` object when parsing corner radii

### DIFF
--- a/lib/classes/context.js
+++ b/lib/classes/context.js
@@ -67,8 +67,8 @@ class CanvasRenderingContext2D extends RustClass{
     let radii = css.radii(r)
     if (radii){
       if (w < 0) radii = [radii[1], radii[0], radii[3], radii[2]]
-      if (h < 0) radii = [radii[3], radii[2], radii[1], radii[0]]
-      this.ƒ("roundRect", x, y, w, h, ...radii.map(({x, y}) => [x, y]).flat())
+      if (h < 0) radii.reverse()
+      this.ƒ("roundRect", x, y, w, h, ...radii.flat())
     }
   }
 

--- a/lib/classes/css.js
+++ b/lib/classes/css.js
@@ -224,21 +224,30 @@ function parseFit(mode){
 //    https://github.com/fserb/canvas2D/blob/master/spec/roundrect.md
 
 function parseCornerRadii(r){
-  r = [r].flat()
-         .map(n => n instanceof DOMPoint ? n : new DOMPoint(n, n))
-         .slice(0, 4)
+  r = [r].flat().slice(0, 4)
 
-  if (r.some(pt => !Number.isFinite(pt.x) || !Number.isFinite(pt.y))){
-    return null // silently abort
-  }else if (r.some(pt => pt.x < 0 || pt.y < 0)){
-    throw new Error("Corner radius cannot be negative")
+  for (let [i, v] of Object.entries(r)) {
+    if (typeof v == 'number') {
+      if (!Number.isFinite(v))
+        return null // silently abort
+      if (v < 0)
+        throw new Error("Corner radius cannot be negative")
+      r[i] = [v, v]
+      continue;
+    }
+    // assume value is an object with {x,y} properties, the isFinite() checks will return false if it isn't
+    if (!Number.isFinite(v.x) || !Number.isFinite(v.y))
+      return null // silently abort
+    if (v.x < 0 || v.y < 0)
+      throw new Error("Corner radius cannot be negative")
+    r[i] = [v.x, v.y]
   }
 
   return r.length == 1 ? [r[0], r[0], r[0], r[0]]
        : r.length == 2 ? [r[0], r[1], r[0], r[1]]
        : r.length == 3 ? [r[0], r[1], r[2], r[1]]
-       : r.length == 4 ? [r[0], r[1], r[2], r[3]]
-       : [0, 0, 0, 0].map(n => new DOMPoint(n, n))
+       : r.length == 4 ? r
+       : [[0,0],[0,0],[0,0],[0,0]]
 }
 
 // -- Image Filters -----------------------------------------------------------------------

--- a/lib/classes/path.js
+++ b/lib/classes/path.js
@@ -65,8 +65,8 @@ class Path2D extends RustClass{
     let radii = css.radii(r)
     if (radii){
       if (w < 0) radii = [radii[1], radii[0], radii[3], radii[2]]
-      if (h < 0) radii = [radii[3], radii[2], radii[1], radii[0]]
-      this.ƒ("roundRect", x, y, w, h, ...radii.map(({x, y}) => [x, y]).flat())
+      if (h < 0) radii.reverse()
+      this.ƒ("roundRect", x, y, w, h, ...radii.flat())
     }
   }
 


### PR DESCRIPTION
… not just `DOMPoint` instances. Which "should" be allowed according to [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/roundRect) and also the skia-canvas definitions...

```ts
interface DOMPointInit {
  x?: number;
  y?: number;
  z?: number;
  w?: number;
}

 roundRect(..., radii?: number | DOMPointInit | (number | DOMPointInit)[]): void;
```

(Although technically the definition for corner radii points should be `{x: number, y: number}` since both are required.)

This also streamlines parsing to return array of `[x,y]` coordinates directly instead of (possibly created) `DOMPoint`s and skips creating new arrays when not necessary. Replaces 4 lambda-capturing iterators with 1 non-capturing.

Thanks!
-Max