### PR TITLE
Add persistent bitmap cache

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -128,7 +128,7 @@ pub fn toBuffer(mut cx: FunctionContext) -> JsResult<JsPromise> {
 
   let channel = cx.channel();
   let (deferred, promise) = cx.promise();
-  rayon::spawn(move || {
+  rayon::spawn_fifo(move || {
     let result = {
       if options.format=="pdf" && pages.len() > 1 {
         pages.as_pdf(options)
@@ -182,7 +182,7 @@ pub fn save(mut cx: FunctionContext) -> JsResult<JsPromise> {
 
   let channel = cx.channel();
   let (deferred, promise) = cx.promise();
-  rayon::spawn(move || {
+  rayon::spawn_fifo(move || {
     let result = {
       if sequence {
         pages.write_sequence(&name_pattern, padding, options)

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -120,8 +120,8 @@ pub fn get_engine_status(mut cx: FunctionContext) -> JsResult<JsString> {
 
 pub fn toBuffer(mut cx: FunctionContext) -> JsResult<JsPromise> {
   let this = cx.argument::<BoxedCanvas>(0)?;
-  let mut pages = pages_arg(&mut cx, 1, &this)?;
   let options = export_options_arg(&mut cx, 2)?;
+  let mut pages = pages_arg(&mut cx, 1, &options, &this)?;
 
   // ensure cached bitmaps are sendable to other thread
   pages.materialize(&this.borrow_mut().engine(), &options);
@@ -149,8 +149,8 @@ pub fn toBuffer(mut cx: FunctionContext) -> JsResult<JsPromise> {
 
 pub fn toBufferSync(mut cx: FunctionContext) -> JsResult<JsValue> {
   let this = cx.argument::<BoxedCanvas>(0)?;
-  let pages = pages_arg(&mut cx, 1, &this)?;
   let options = export_options_arg(&mut cx, 2)?;
+  let pages = pages_arg(&mut cx, 1, &options, &this)?;
 
   let encoded = {
     if options.format=="pdf" && pages.len() > 1 {
@@ -171,11 +171,11 @@ pub fn toBufferSync(mut cx: FunctionContext) -> JsResult<JsValue> {
 
 pub fn save(mut cx: FunctionContext) -> JsResult<JsPromise> {
   let this = cx.argument::<BoxedCanvas>(0)?;
-  let mut pages = pages_arg(&mut cx, 1, &this)?;
   let name_pattern = string_arg(&mut cx, 2, "filePath")?;
   let sequence = !cx.argument::<JsValue>(3)?.is_a::<JsUndefined, _>(&mut cx);
   let padding = opt_float_arg(&mut cx, 3).unwrap_or(-1.0);
   let options = export_options_arg(&mut cx, 4)?;
+  let mut pages = pages_arg(&mut cx, 1, &options, &this)?;
 
   // ensure cached bitmaps are sendable to other thread
   pages.materialize(&this.borrow_mut().engine(), &options);
@@ -204,11 +204,11 @@ pub fn save(mut cx: FunctionContext) -> JsResult<JsPromise> {
 
 pub fn saveSync(mut cx: FunctionContext) -> JsResult<JsUndefined> {
   let this = cx.argument::<BoxedCanvas>(0)?;
-  let pages = pages_arg(&mut cx, 1, &this)?;
   let name_pattern = string_arg(&mut cx, 2, "filePath")?;
   let sequence = !cx.argument::<JsValue>(3)?.is_a::<JsUndefined, _>(&mut cx);
   let padding = opt_float_arg(&mut cx, 3).unwrap_or(-1.0);
   let options = export_options_arg(&mut cx, 4)?;
+  let pages = pages_arg(&mut cx, 1, &options, &this)?;
 
   let result = {
     if sequence {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -507,6 +507,10 @@ impl Context2D{
     self.recorder.lock().unwrap().get_page()
   }
 
+  pub fn get_page_for_export(&self, opts:&ExportOptions, engine:&RenderingEngine) -> Page {
+    self.recorder.lock().unwrap().get_page_for_export(opts, engine)
+  }
+
   pub fn get_image(&self) -> Option<Image> {
     self.recorder.lock().unwrap().get_image()
   }

--- a/src/context/page.rs
+++ b/src/context/page.rs
@@ -337,10 +337,11 @@ impl Page{
       }
 
       // handle bitmap formats using (potentially gpu-backed) rasterizer
-      _ => engine.with_surface(&img_info, &options, |surface|{
+      _ => {
+        let mut surface = engine.make_surface(&img_info, &options)?;
         let canvas = surface.canvas();
-        let (cache_image, cache_depth) = PageCache::get(self.id, &options, self.depth());
 
+        let (cache_image, cache_depth) = PageCache::get(self.id, &options, self.depth());
         if let Some(image) = cache_image{
           // use the cached bitmap as the background
           canvas.draw_image(image, (0,0), None);
@@ -455,7 +456,7 @@ impl Page{
           }
           _ => return Err(format!("Unsupported file format {}", format))
         }.ok_or(format!("Could not encode as {}", format))
-      })
+      }
     }
   }
 

--- a/src/context/page.rs
+++ b/src/context/page.rs
@@ -247,7 +247,7 @@ impl RecordingSurface{
   }
 
   pub fn snapshot_if_valid(&mut self, page:&Page, opts:&ExportOptions, engine:&RenderingEngine) -> Option<SkImage>{
-    match !(self.is_config_stale(&opts) || self.is_surface_stale(&page, &opts, &engine)){
+    match !(self.is_config_stale(&opts) || self.is_surface_stale(&page, &opts, &engine) || self.depth==0){
       true => self.surface.as_mut().map(|surface| surface.image_snapshot()),
       false => None,
     }

--- a/src/gpu/metal.rs
+++ b/src/gpu/metal.rs
@@ -99,18 +99,15 @@ impl MetalEngine {
     }
 
     pub fn with_direct_context<F>(f:F)
-        where F:FnOnce(&mut DirectContext)
+        where F:FnOnce(Option<&mut DirectContext>)
     {
-        Self::with_context(|ctx| Ok(f(&mut ctx.context)) ).ok();
+        Self::with_context(|ctx| Ok(f(Some(&mut ctx.context))) ).ok();
     }
 
-    pub fn with_surface<T, F>(image_info: &ImageInfo, opts:&ExportOptions, f:F) -> Result<T, String>
-        where F:FnOnce(&mut Surface) -> Result<T, String>
-    {
-        Self::with_context(|ctx|
-            ctx.surface(image_info, opts).and_then(|mut surface| f(&mut surface) )
-        )
+    pub fn make_surface(image_info: &ImageInfo, opts:&ExportOptions) -> Result<Surface, String>{
+        Self::with_context(|ctx| ctx.surface(image_info, opts) )
     }
+
 }
 pub struct MetalContext {
     device: Device,

--- a/src/gpu/metal.rs
+++ b/src/gpu/metal.rs
@@ -120,7 +120,7 @@ pub struct MetalContext {
 }
 
 impl MetalContext{
-    fn new() -> Option<Self>{
+    pub fn new() -> Option<Self>{
         autoreleasepool(|| {
             Device::system_default().and_then(|device|{
                 let queue = device.new_command_queue();
@@ -140,7 +140,7 @@ impl MetalContext{
         })
     }
 
-    fn surface(&mut self, image_info: &ImageInfo, opts:&ExportOptions) -> Result<Surface, String> {
+    pub fn surface(&mut self, image_info: &ImageInfo, opts:&ExportOptions) -> Result<Surface, String> {
         self.last_use = self.last_use.max(Instant::now());
         surfaces::render_target(
             &mut self.context,

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -23,18 +23,16 @@ struct Engine { }
 #[cfg(not(any(feature = "vulkan", feature = "metal")))]
 impl Engine {
     pub fn supported() -> bool { false }
-    pub fn with_direct_context<T, F>(_f:F) -> Option<T>{ None }
-    pub fn with_surface<T, F>(_: &ImageInfo, _:&ExportOptions, _:F)  -> Result<T, String>
-        where F:FnOnce(&mut Surface) -> Result<T, String>
-    {
-        Err("Compiled without GPU support".to_string())
-    }
     pub fn status() -> Value { serde_json::json!({
         "renderer": "CPU",
         "api": Value::Null,
         "device": "CPU-based renderer (compiled without GPU support)",
         "error": Value::Null,
     })}
+    // placeholders that match the GPU signatures (for the type-checker) but will never be called
+    // (see the RenderingEngine methods for their inline implementation when in CPU mode)
+    pub fn make_surface(_info: &ImageInfo, _opts:&ExportOptions) -> Result<Surface, String>{ panic!() }
+    pub fn with_direct_context(_f:impl FnOnce(Option<&mut DirectContext>)){ panic!() }
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -60,25 +58,17 @@ impl RenderingEngine{
 
     pub fn make_surface(&self, image_info: &ImageInfo, opts:&ExportOptions) -> Result<Surface, String>{
         match self {
-            Self::GPU => Engine::with_context(|ctx| ctx.surface(image_info, opts) ),
+            Self::GPU => Engine::make_surface(image_info, opts),
             Self::CPU => surfaces::raster(image_info, None, Some(&opts.surface_props()))
                 .ok_or(format!("Could not allocate new {}×{} bitmap", image_info.width(), image_info.height()))
         }
     }
 
-    pub fn with_surface<T,F>(&self, image_info: &ImageInfo, opts:&ExportOptions, f:F) -> Result<T, String>
-        where F:FnOnce(&mut Surface) -> Result<T, String>
-    {
+    pub fn with_direct_context(&self, f:impl FnOnce(Option<&mut DirectContext>)){
         match self {
-            Self::GPU => Engine::with_surface(image_info, opts, f),
-            Self::CPU => surfaces::raster(image_info, None, Some(&opts.surface_props()))
-                .ok_or(format!("Could not allocate new {}×{} bitmap", image_info.width(), image_info.height()))
-                .and_then(|mut surface|f(&mut surface))
+            Self::GPU => Engine::with_direct_context(f),
+            Self::CPU => f(None)
         }
-    }
-
-    pub fn with_direct_context(&self, f:impl FnOnce(&mut DirectContext)){
-        Engine::with_direct_context(f);
     }
 
     pub fn status(&self) -> serde_json::Value {

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -58,6 +58,14 @@ impl RenderingEngine{
         }
     }
 
+    pub fn make_surface(&self, image_info: &ImageInfo, opts:&ExportOptions) -> Result<Surface, String>{
+        match self {
+            Self::GPU => Engine::with_context(|ctx| ctx.surface(image_info, opts) ),
+            Self::CPU => surfaces::raster(image_info, None, Some(&opts.surface_props()))
+                .ok_or(format!("Could not allocate new {}×{} bitmap", image_info.width(), image_info.height()))
+        }
+    }
+
     pub fn with_surface<T,F>(&self, image_info: &ImageInfo, opts:&ExportOptions, f:F) -> Result<T, String>
         where F:FnOnce(&mut Surface) -> Result<T, String>
     {

--- a/src/gpu/vulkan/engine.rs
+++ b/src/gpu/vulkan/engine.rs
@@ -117,45 +117,17 @@ impl VulkanEngine {
                     })
             })
         }
-
     }
 
     pub fn with_direct_context<F>(f:F)
-        where F:FnOnce(&mut DirectContext)
+        where F:FnOnce(Option<&mut DirectContext>)
     {
-        Self::with_context(|ctx| Ok(f(&mut ctx.context)) ).ok();
+        Self::with_context(|ctx| Ok(f(Some(&mut ctx.context))) ).ok();
     }
 
-    pub fn with_surface<T, F>(image_info: &ImageInfo, opts:&ExportOptions, f:F) -> Result<T, String>
-        where F:FnOnce(&mut Surface) -> Result<T, String>
-    {
-        Self::with_context(|ctx|
-            ctx.surface(image_info, opts).and_then(|mut surface| f(&mut surface) )
-        )
-    }
 
-    pub fn _with_surface<T, F>(image_info: &ImageInfo, opts:&ExportOptions, f:F) -> Result<T, String>
-        where F:FnOnce(&mut Surface) -> Result<T, String>
-    {
-        match VulkanEngine::supported() {
-            false => Err("Vulkan API not supported".to_string()),
-            true => VK_CONTEXT.with_borrow_mut(|local_ctx|{
-                local_ctx
-                    // lazily initialize this thread's context...
-                    .take()
-                    .or_else(|| VulkanContext::new().ok() )
-                    .ok_or("Vulkan initialization failed".to_string())
-                    .and_then(|ctx|{
-                        let ctx = local_ctx.insert(ctx);
-                        // ...then create the surface with it...
-                        ctx.surface(image_info, opts)
-                    })
-                    .and_then(|mut surface|
-                        // ... finally let the callback use it
-                        f(&mut surface)
-                    )
-            })
-        }
+    pub fn make_surface(image_info: &ImageInfo, opts:&ExportOptions) -> Result<Surface, String>{
+        Self::with_context(|ctx| ctx.surface(image_info, opts) )
     }
 }
 


### PR DESCRIPTION
This PR adds a `RecordingSurface` struct to the `PageRecorder` that holds the vector draw-list for a given context. Previously, this list of drawing commands was re-executed each time the canvas was rasterized for a *getImageData()* call, leading to ever-increasing render times as the number of vector objects accumulated (see #152).

The new approach is to hold a persistent reference to the bitmap rendering [Surface](https://rust-skia.github.io/doc/skia_safe/type.Surface.html) between calls and to render only the newly-added vector objects when *getImageData()* is called. The surface cache will be cleared if any of the following change between calls:
- the `density`, `msaa`, or `matte` optional arguments passed to *getImageData()*
- the canvas's `gpu` setting
- the canvas's dimensions (or anything else that clears it like *ctx.reset()* or a full-frame *ctx.clearRect()*)

The surface cache works in tandem with the [Image](https://rust-skia.github.io/doc/skia_safe/type.Image.html)-based `PageCache` that is updated when bitmaps are exported via *canvas.saveAs()*, *canvas.toBuffer()*, etc. When *getImageData()* is called, it will attempt to use the `PageCache` bitmap if it is more recent. Likewise, when an export method is called, the `PageCache` will be updated with the current `RecordingSurface` bitmap if it's newer.

These caching changes add a small amount of overhead, but make a huge difference in certain ‘worst case scenario’ access patterns such as this loop which repeatedly reads and writes to the canvas:

```js
  const size = 512
  const coord = (max=size) => 1 + Math.random(max-1)

  for (let i=0; i<1000; i++){
    let [x,y] = [coord(), coord()]
    let [w,h] = [coord(size-x), coord(size-y)]
    let img = ctx.getImageData(x, y, w, h)
    ctx.putImageData(img, coord(), coord())
  }
```

Previously this would lead to a rapidly growing stack of draw-list items that would be re-executed from scratch on each *getImageData()* call. Now only the newly added *putImageData()* needs to be run in a given loop iteration, leading to a substantial speed improvement: 
<img width="702" height="638" alt="Artboard 1@2x" src="https://github.com/user-attachments/assets/d9cf2b14-31d6-4daf-ba9d-c96c11e6a7fe" />

