### PR TITLE
Add configurable binary mirror host for restricted networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,28 @@ Alternatively, you can add a [`pnpm.onlyBuiltDependencies`](https://pnpm.io/9.x/
 
 
 
+### Binary Mirror
+
+If your environment restricts access to GitHub (e.g., a corporate network or air-gapped CI), you can redirect the prebuilt binary download to an internal mirror. The mirror must serve files at the same path structure as GitHub Releases: `{host}/v{version}/{platform}-{arch}-{libc}.gz`.
+
+Set the mirror host via an environment variable:
+```bash
+SKIA_CANVAS_BINARY_HOST=https://your.internal.mirror/skia-canvas npm install skia-canvas
+```
+
+Or via an npm config flag:
+```bash
+npm install skia-canvas --skia_canvas_binary_host_mirror=https://your.internal.mirror/skia-canvas
+```
+
+If neither is set, the default GitHub Releases URL is used.
+
+For authenticated mirrors (e.g., Artifactory), embed credentials in the URL:
+```bash
+SKIA_CANVAS_BINARY_HOST=https://user:token@artifactory.example.com/skia-canvas npm install skia-canvas
+```
+
+
 ## Platform Support
 
 Skia Canvas runs on Linux, macOS, or Windows as well as serverless platforms like Vercel and AWS Lambda. Precompiled versions of the library’s native code will be automatically downloaded in the appropriate architecture (`arm64` or `x64`) when you install it via npm.

--- a/lib/prebuild.mjs
+++ b/lib/prebuild.mjs
@@ -82,7 +82,8 @@ async function download(...args){
     if (existsSync(BINARY_PATH)) return // nothing to be done if skia.node already exists
 
     let {version, triplet, prebuild} = await config(),
-        url = `${BINARY_HOST}/v${version}/${triplet}.gz`,
+        host = process.env.npm_config_skia_canvas_binary_host_mirror || process.env.SKIA_CANVAS_BINARY_HOST || BINARY_HOST,
+        url = `${host}/v${version}/${triplet}.gz`,
         agent = PROXY_URL ? new HttpsProxyAgent(PROXY_URL) : undefined
 
     try{


### PR DESCRIPTION
Fixes #287

## Summary

- Adds support for redirecting the prebuilt binary download to an internal mirror via `SKIA_CANVAS_BINARY_HOST` env var or `--skia_canvas_binary_host_mirror` npm config flag
- Falls back to the default GitHub Releases URL if neither is set
- Documents the feature in the Installation section of the README

## Test plan

- [ ] Install with `SKIA_CANVAS_BINARY_HOST` set to a mirror and verify the binary is fetched from that host
- [ ] Install with `--skia_canvas_binary_host_mirror` flag and verify the binary is fetched from that host
- [ ] Install without either set and verify default behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)