### PR TITLE
Add premultiplied option for raw pixel exports

### DIFF
--- a/lib/classes/canvas.js
+++ b/lib/classes/canvas.js
@@ -230,7 +230,7 @@ function exportOptions(canvas, {filename='', extension=''}, opts){
   if (typeof opts=='number') opts = {quality:opts}
 
   // unpack common export options
-  let {page, quality, matte, density, msaa, outline, downsample, colorType} = opts
+  let {page, quality, matte, density, msaa, outline, downsample, colorType, premultiplied} = opts
 
   // only allow format overrides in toFile()
   let imageFormat = !!filename ? opts.format : undefined
@@ -305,10 +305,11 @@ function exportOptions(canvas, {filename='', extension=''}, opts){
   // default to false, otherwise detect truthy
   downsample = !!downsample
   outline = !!outline
+  premultiplied = !!premultiplied
 
   return {
     filename, pattern, format, mime, pages, padding, quality, matte,
-    density, msaa, outline, textContrast, textGamma, downsample, colorType
+    density, msaa, outline, textContrast, textGamma, downsample, colorType, premultiplied
   }
 }
 

--- a/lib/classes/context.js
+++ b/lib/classes/context.js
@@ -174,7 +174,7 @@ class CanvasRenderingContext2D extends RustClass{
     return new ImageData(width, height, settings)
   }
 
-  getImageData(x, y, width, height, {colorType='rgba', colorSpace='srgb', density=1, matte, msaa}={}){
+  getImageData(x, y, width, height, {colorType='rgba', colorSpace='srgb', density=1, matte, msaa, premultiplied=false}={}){
     argc(arguments, 4, 5)
 
     if (typeof density!='number' || !Number.isInteger(density) || density<1){
@@ -187,7 +187,7 @@ class CanvasRenderingContext2D extends RustClass{
       throw new TypeError("The number of MSAA samples must be an integer ≥0")
     }
 
-    let opts = {colorType, colorSpace, density, matte, msaa},
+    let opts = {colorType, colorSpace, density, matte, msaa, premultiplied: !!premultiplied},
         buffer = this.ƒ('getImageData', x, y, width, height, opts, core(this.canvas));
     return new ImageData(buffer, width*density, height*density, {colorType, colorSpace})
   }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -154,6 +154,9 @@ interface ImageDataExportSettings {
 
   /** Color type to use when exporting in "raw" format */
   colorType?: ColorType
+
+  /** Return pixel data in premultiplied-alpha form (defaults to false) */
+  premultiplied?: boolean
 }
 
 
@@ -309,6 +312,9 @@ export interface ExportOptions extends RenderOptions {
 
   /** Color type to use when exporting in "raw" format */
   colorType?: ColorType
+
+  /** Return pixel data in premultiplied-alpha form (only applies when exporting in "raw" format) */
+  premultiplied?: boolean
 }
 
 export interface SaveOptions extends ExportOptions {

--- a/src/context/api.rs
+++ b/src/context/api.rs
@@ -813,7 +813,7 @@ pub fn getImageData(mut cx: FunctionContext) -> JsResult<JsBuffer> {
   let mut y = float_arg(&mut cx, 2, "y")?.floor();
   let mut w = float_arg(&mut cx, 3, "width")?.floor();
   let mut h = float_arg(&mut cx, 4, "height")?.floor();
-  let (color_type, color_space, matte, density, msaa) = image_data_export_arg(&mut cx, 5);
+  let (color_type, color_space, matte, density, msaa, premultiplied) = image_data_export_arg(&mut cx, 5);
   let parent = cx.argument::<BoxedCanvas>(6)?;
   let canvas = &mut parent.borrow_mut();
 
@@ -821,7 +821,7 @@ pub fn getImageData(mut cx: FunctionContext) -> JsResult<JsBuffer> {
   if w < 0.0 { x += w; w *= -1.0; }
   if h < 0.0 { y += h; h *= -1.0; }
 
-  let opts = ExportOptions{matte, density, msaa, color_type, color_space, ..canvas.export_options()};
+  let opts = ExportOptions{matte, density, msaa, color_type, color_space, premultiplied, ..canvas.export_options()};
   let crop = Rect::from_point_and_size((x*density, y*density), (w*density, h*density)).round();
   let engine = canvas.engine();
 

--- a/src/context/page.rs
+++ b/src/context/page.rs
@@ -95,7 +95,8 @@ impl PageRecorder{
 
   pub fn get_pixels(&mut self, crop:IRect, opts:ExportOptions, engine:RenderingEngine) -> Result<Vec<u8>, String>{
     // return an empty buffer if the requested rect is entirely outside the canvas
-    let dst_info = ImageInfo::new((crop.width(), crop.height()), opts.color_type.clone(), AlphaType::Unpremul, opts.color_space.clone());
+    let alpha_type = if opts.premultiplied { AlphaType::Premul } else { AlphaType::Unpremul };
+    let dst_info = ImageInfo::new((crop.width(), crop.height()), opts.color_type.clone(), alpha_type, opts.color_space.clone());
     let mut dst_buffer: Vec<u8> = vec![0; dst_info.compute_min_byte_size()];
     if !self.bounds.intersects(Rect::from_irect(crop)){
       return Ok(dst_buffer)
@@ -377,7 +378,8 @@ impl Page{
         // handle image encoding
         match format.as_str(){
           "raw" => {
-            let dst_info = ImageInfo::new(img_dims, color_type, AlphaType::Unpremul, Some(ColorSpace::new_srgb()));
+            let alpha_type = if options.premultiplied { AlphaType::Premul } else { AlphaType::Unpremul };
+            let dst_info = ImageInfo::new(img_dims, color_type, alpha_type, Some(ColorSpace::new_srgb()));
             let mut buffer: Vec<u8> = vec![0; dst_info.compute_min_byte_size()];
             match surface.read_pixels(&dst_info, &mut buffer, dst_info.min_row_bytes(), (0,0)){
               true => Some(buffer),
@@ -686,6 +688,7 @@ pub struct ExportOptions{
   pub jpeg_downsample: bool,
   pub text_contrast: f32,
   pub text_gamma: f32,
+  pub premultiplied: bool,
 }
 
 impl Default for ExportOptions{
@@ -694,6 +697,7 @@ impl Default for ExportOptions{
       format:"raw".to_string(), quality:0.92, density:1.0, matte:None,
       jpeg_downsample:false, text_contrast:0.0, text_gamma:1.4, msaa:None,
       color_type:ColorType::RGBA8888, color_space:ColorSpace::new_srgb(), outline:true,
+      premultiplied:false,
     }
   }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -218,6 +218,12 @@ pub fn bool_for_key(cx: &mut FunctionContext, obj: &Handle<JsObject>, attr:&str)
   }
 }
 
+pub fn opt_bool_for_key(cx: &mut FunctionContext, obj: &Handle<JsObject>, attr:&str) -> Option<bool>{
+  obj.get(cx, attr).ok()
+    .and_then(|val:Handle<JsValue>| val.downcast::<JsBoolean, _>(cx).ok() )
+    .map(|v| v.value(cx))
+}
+
 //
 // floats
 //
@@ -563,7 +569,7 @@ pub fn image_data_settings_arg(cx: &mut FunctionContext, idx:usize) -> (ColorTyp
   }
 }
 
-pub fn image_data_export_arg(cx: &mut FunctionContext, idx:usize) -> (ColorType, ColorSpace, Option<Color>, f32, Option<usize>){
+pub fn image_data_export_arg(cx: &mut FunctionContext, idx:usize) -> (ColorType, ColorSpace, Option<Color>, f32, Option<usize>, bool){
   match opt_object_arg(cx, idx){
     Some(obj) => {
       let color_type = opt_string_for_key(cx, &obj, "colorType").unwrap_or("rgba".to_string());
@@ -571,9 +577,10 @@ pub fn image_data_export_arg(cx: &mut FunctionContext, idx:usize) -> (ColorType,
       let matte = opt_color_for_key(cx, &obj, "matte");
       let density = opt_float_for_key(cx, &obj, "density").unwrap_or(1.0);
       let msaa = opt_float_for_key(cx, &obj, "msaa").map(|n| n as usize);
-      (to_color_type(&color_type), to_color_space(&color_space), matte, density, msaa)
+      let premultiplied = opt_bool_for_key(cx, &obj, "premultiplied").unwrap_or(false);
+      (to_color_type(&color_type), to_color_space(&color_space), matte, density, msaa, premultiplied)
     }
-    None => (ColorType::RGBA8888, ColorSpace::new_srgb(), None, 1.0, None)
+    None => (ColorType::RGBA8888, ColorSpace::new_srgb(), None, 1.0, None, false)
   }
 }
 
@@ -659,6 +666,7 @@ pub fn export_options_arg(cx: &mut FunctionContext, idx: usize) -> NeonResult<Ex
   let quality = float_for_key(cx, &opts, "quality")?;
   let density = float_for_key(cx, &opts, "density")?;
   let jpeg_downsample = bool_for_key(cx, &opts, "downsample")?;
+  let premultiplied = bool_for_key(cx, &opts, "premultiplied")?;
   let matte = opt_color_for_key(cx, &opts, "matte");
   let msaa = opt_float_for_key(cx, &opts, "msaa")
     .map(|num| num.floor() as usize);
@@ -671,7 +679,8 @@ pub fn export_options_arg(cx: &mut FunctionContext, idx: usize) -> NeonResult<Ex
   let color_space = ColorSpace::new_srgb();
 
   Ok(ExportOptions{
-    format, quality, density, outline, matte, msaa, color_type, color_space, jpeg_downsample, text_contrast, text_gamma
+    format, quality, density, outline, matte, msaa, color_type, color_space, jpeg_downsample, text_contrast, text_gamma,
+    premultiplied,
   })
 }
 


### PR DESCRIPTION
Currently `getImageData`, `toBuffer('raw')`, and `toBufferSync('raw')` all return RGBA pixel data in unpremultiplied (straight alpha) form, consistent with the HTML Canvas specification. Although the underlying canvas bitmap is typically stored in premultiplied form, every read-back path performs automatic unpremultiplication, and there is no API for retrieving the premultiplied pixel data directly.

### Why this matters
- Premultiplied alpha is commonly preferred for GPU upload paths because it matches the representation used by GPU blending pipelines. Applications therefore typically need to re-premultiply the data during upload. This introduces unnecessary overhead when the original pixel data was already premultiplied before skia-canvas unpremultiplied it during read-back.
- The premultiplied-unpremultiplied-premultiplied round-trip is lossy at low alpha values, since unpremultiplication quantizes color channels.

### Implementation
Add a new boolean option, `premultiplied` (defaulting to `false`). When enabled, the `ImageInfo` is constructed with `AlphaType::Premul` instead of `AlphaType::Unpremul`, bypassing unpremultiplication and returning the underlying premultiplied pixel data directly.