### PR TITLE
Allow custom binary host via environment variable

### DIFF
--- a/lib/prebuild.mjs
+++ b/lib/prebuild.mjs
@@ -15,7 +15,7 @@ const exec = promisify(child_process.exec);
 
 const ROOT = resolve(`${import.meta.dirname}/..`)
 const REPO_URL = "https://github.com/samizdatco/skia-canvas"
-const BINARY_HOST = `${REPO_URL}/releases/download`
+const BINARY_HOST = process.env.SKIA_CANVAS_BINARY_HOST || `${REPO_URL}/releases/download`
 const BINARY_PATH = `${ROOT}/lib/skia.node`
 const PACKAGE_JSON = `${ROOT}/package.json`
 const PROXY_URL =


### PR DESCRIPTION
Allow custom binary host via environment variable

Adds support for SKIA_CANVAS_BINARY_HOST environment variable to override the default binary download host, helping users in regions with network restrictions or behind corporate firewalls to specify a mirror/CDN endpoint.