### PR TITLE
Fix full-canvas fill optimization never firing

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -356,7 +356,9 @@ impl Context2D{
       self.state.fill_style.is_opaque() &&
       self.state.global_alpha == 1.0 &&
       self.state.clip.is_none() &&
-      path.conservatively_contains_rect(self.bounds)
+      // conservativelyContainsRect rejects even an exactly-fitting rect, so test those directly
+      (path.is_rect().is_some_and(|(rect, _, _)| self.state.matrix.map_rect(rect).0.contains(self.bounds)) ||
+       path.conservatively_contains_rect(self.bounds))
     {
       // ...erase existing vector content layers (but preserve CTM & clip path)
       self.with_recorder(|mut recorder|{


### PR DESCRIPTION
# Fix full-canvas fill optimization never firing

`Context2D::draw_path` has a fast path that discards accumulated vector layers when a
draw provably paints over the entire canvas. The guard on that fast path can never be
true, so the optimization has never fired and `PageRecorder`'s layer list grows without
bound — one `Picture` per draw, for the lifetime of the canvas.

## The bug

The predicate ends with `path.conservatively_contains_rect(self.bounds)`. I instrumented
each term of the condition and ran `fillRect(0, 0, width, height)` on a 1200×900 canvas:

```
style_ok=true blend_ok=true opaque=true alpha=1 noclip=true contains=false
```

Every condition passes except the last. `SkPath::conservativelyContainsRect` returns
false even for a rect path that exactly covers `bounds` — it is documented as
conservative and is allowed to answer false negatively.

The consequence is that `clearRect(0, 0, w, h)` resets the recorder (via `Context2D::clear_rect`,
which takes a different route) while an opaque, equally-occluding `fillRect(0, 0, w, h)`
does not. Long-lived canvases that repaint a full-canvas background each frame — the
common pattern for server-side rendering — accumulate a layer per frame forever.

## The fix

Test rectangular paths directly against the transformed rect, and fall back to the
conservative check for everything else:

```rust
(path.is_rect().is_some_and(|(rect, _, _)| self.state.matrix.map_rect(rect).0.contains(self.bounds)) ||
 path.conservatively_contains_rect(self.bounds))
```

`fillRect` and a `rect()` subpath both produce a rect path, so this covers the case that
matters in practice while leaving non-rect paths on the existing behaviour.

## Measurements

Second-half RSS slope over 2000 renders, KiB per render. Negative means memory is being
returned. A standalone reproducer is at the end.

| | main | this PR |
|---|---|---|
| `toBufferSync`, CPU | 25.5 | **−1.2** |
| `toBuffer`, CPU | 26.2 | **−0.7** |
| `toBufferSync`, GPU | 25.0 | **−1.6** |
| `toBuffer`, GPU | 101.9 | 88.9 |

Reproduced 3–5 runs per cell.

The GPU async cell is only partly addressed here because a second, unrelated leak is
present on that path — Metal allocations on rayon workers with no autorelease pool.
That is #297; the two are independent and compose (all four cells land at
roughly −1 with both applied).

## Testing

- `npm test` — 141/141 pass.
- `cargo clippy` — no new warnings on the changed lines.

## Notes

- There is a second `conservatively_contains_rect` call in `clip()` with the same
  limitation. The consequence there is a redundant retained clip path rather than
  unbounded growth, so I left it alone.
- Measured on macOS 26.6 / Apple M4 Pro / Node v26.4.0, against 3.0.8. Not measured on
  Linux or Windows, though the affected code is renderer-independent and the CPU cells
  above exercise the same raster path CI would.

## Reproducer

```js
// node --expose-gc repro.js
const { Canvas } = require('skia-canvas')

function main() {
  const canvas = new Canvas(1200, 900)
  canvas.gpu = false          // note: the constructor ignores a third options argument
  const ctx = canvas.getContext('2d')
  const samples = []

  for (let i = 0; i < 2000; i++) {
    ctx.fillStyle = '#DFCCAE'
    ctx.fillRect(0, 0, 1200, 900)     // opaque, covers the canvas, should reset the recorder
    ctx.fillStyle = '#2E1F22'
    ctx.font = 'bold 28px sans-serif'
    ctx.fillText(`frame ${i}`, 24, 48)
    ctx.font = '14px sans-serif'
    for (let r = 0; r < 6; r++) {
      for (let c = 0; c < 5; c++) {
        const x = 24 + c * 232, y = 80 + r * 130
        ctx.strokeStyle = '#745557'
        ctx.strokeRect(x, y, 220, 120)
        ctx.fillText(`${i}-${r}-${c}`, x + 8, y + 20)
      }
    }
    canvas.toBufferSync('png')

    if (i % 100 === 0) {
      global.gc(); global.gc()
      samples.push({ i, rss: process.memoryUsage().rss / 1048576 })
    }
  }

  const mid = samples.length >> 1
  const tail = samples.slice(mid)
  const slope = (tail.at(-1).rss - tail[0].rss) * 1024 / (tail.at(-1).i - tail[0].i)
  console.log(`${slope.toFixed(1)} KiB/render`)
}

main()
```

On this machine that prints `26.8 KiB/render` on `main` and `0.1 KiB/render` with the
patch. (It reports a touch higher than the table above, which samples RSS more finely —
the direction and magnitude are what matter.)

Swapping the `fillRect` for `clearRect(0, 0, 1200, 900)` flattens the growth on `main`,
which isolates the failing predicate.
