### PR TITLE
Support locked named variable-font instances

### DIFF
--- a/docs/api/font-library.md
+++ b/docs/api/font-library.md
@@ -54,6 +54,7 @@ Uninstalls any dynamically loaded fonts that had been added via `FontLibrary.use
 FontLibrary.use([...fontPaths])
 FontLibrary.use(familyName, [...fontPaths])
 FontLibrary.use({familyName:[...fontPaths], ...)
+FontLibrary.use(familyName, {path, namedInstance})
 ```
 
 The `FontLibrary.use()` method allows you to dynamically load local font files and use them with your canvases. It can read fonts in the OpenType (`.otf`), TrueType (`.ttf`), and web-font (`.woff` & `.woff2`) file formats.
@@ -97,6 +98,19 @@ The return value will be either a list or an object (matching the style in which
   width: 'normal',
   file: 'fonts/Oswald-SemiBold.ttf'
 }
+```
+
+#### with a named variable-font instance
+
+Pass a one-based `fvar` named-instance index to register that instance as a
+fixed face. Its variation coordinates remain locked even when a canvas font
+string requests a different weight.
+
+```js
+FontLibrary.use("Example Light", {
+  path: "fonts/Example-Variable.ttf",
+  namedInstance: 3,
+})
 ```
 
 #### with a list of ‘glob’ patterns

--- a/lib/classes/typography.js
+++ b/lib/classes/typography.js
@@ -6,6 +6,21 @@
 
 const {RustClass, readOnly, signature, inspect, REPR} = require('./neon')
 
+const fontSource = source => {
+  if (typeof source == 'string') return {path:source, index:0}
+
+  let {path, namedInstance} = source || {}
+  if (typeof path != 'string' ||
+      !Number.isSafeInteger(namedInstance) ||
+      namedInstance < 1 || namedInstance > 0x7fff){
+    throw new Error("Expected a font path or a named font instance")
+  }
+
+  // Skia follows FreeType's convention of storing the one-based named-instance
+  // index in the upper 16 bits of the collection index.
+  return {path, index:namedInstance << 16}
+}
+
 class FontLibrary extends RustClass {
   constructor(){
     super(FontLibrary)
@@ -21,16 +36,17 @@ class FontLibrary extends RustClass {
     let sig = signature(args)
     if (sig=='o'){
       let results = {}
-      for (let [alias, paths] of Object.entries(args.shift())){
-        results[alias] = this.ƒ("addFamily", alias, [paths].flat())
+      for (let [alias, sources] of Object.entries(args.shift())){
+        let fonts = [sources].flat().map(fontSource)
+        results[alias] = this.ƒ("addFamily", alias, fonts.map(({path}) => path), fonts.map(({index}) => index))
       }
       return results
-    }else if (sig.match(/^s?[as]$/)){
-      let fonts = [args.pop()].flat()
+    }else if (sig.match(/^s?[as]$/) || sig=='so'){
+      let fonts = [args.pop()].flat().map(fontSource)
       let alias = args.shift()
-      return this.ƒ("addFamily", alias, fonts)
+      return this.ƒ("addFamily", alias, fonts.map(({path}) => path), fonts.map(({index}) => index))
     }else{
-      throw new Error("Expected an array of file paths or an object mapping family names to font files")
+      throw new Error("Expected font sources or an object mapping family names to font sources")
     }
   }
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -913,15 +913,23 @@ export interface Font {
   file: string
 }
 
+export interface NamedFontInstance {
+  path: string
+  /** One-based index in the font's fvar named-instance array. */
+  namedInstance: number
+}
+
+export type FontSource = string | NamedFontInstance
+
 interface FontLibrary {
   families: readonly string[]
   family(name: string): FontFamily | undefined
   has(familyName: string): boolean
 
-  use(familyName: string, fontPaths?: string | readonly string[]): Font[]
-  use(fontPaths: readonly string[]): Font[]
+  use(familyName: string, fontPaths?: FontSource | readonly FontSource[]): Font[]
+  use(fontPaths: readonly FontSource[]): Font[]
   use(
-    families: Record<string, readonly string[] | string>
+    families: Record<string, readonly FontSource[] | FontSource>
   ): Record<string, Font[]>
 
   reset(): void

--- a/src/font_library.rs
+++ b/src/font_library.rs
@@ -46,6 +46,7 @@ pub struct FontLibrary{
     mgr: FontMgr,
     collection: Option<FontCollection>,
     fonts: Vec<(Typeface, Option<String>)>,
+    locked_fonts: Vec<Typeface>,
     generics_cache: Vec<(Typeface, Option<String>)>,
     collection_cache: HashMap<CollectionKey, FontCollection>,
     collection_hinted: bool,
@@ -71,7 +72,7 @@ impl FontLibrary{
         }
 
         RefCell::new(FontLibrary{
-          mgr:FontMgr::default(), fonts:vec![], collection:None, collection_cache:HashMap::new(), collection_hinted:false, generics_cache:vec![]
+          mgr:FontMgr::default(), fonts:vec![], locked_fonts:vec![], collection:None, collection_cache:HashMap::new(), collection_hinted:false, generics_cache:vec![]
         })
       });
 
@@ -212,7 +213,9 @@ impl FontLibrary{
       weights.push(*style.weight());
       if let Some(font) = var_fc.find_typefaces(&[&family], style).first(){
         // for variable fonts, report all the 100× sizes they support within their wght range
-        weights.append(&mut typeface_wght_range(font));
+        if !self.locked_fonts.iter().any(|locked| Typeface::equal(font, locked)) {
+          weights.append(&mut typeface_wght_range(font));
+        }
       }
     });
 
@@ -227,7 +230,7 @@ impl FontLibrary{
     (weights, widths, styles)
   }
 
-  fn add_typeface(&mut self, font:Typeface, alias:Option<String>){
+  fn add_typeface(&mut self, font:Typeface, alias:Option<String>, locked:bool){
     // replace any previously added font with the same metadata/alias
     if let Some(idx) = self.fonts.iter().position(|(old_font, old_alias)|
       match alias.is_some(){
@@ -235,10 +238,16 @@ impl FontLibrary{
         false => old_font.family_name() == font.family_name()
       } && old_font.font_style() == font.font_style()
     ){
-      self.fonts.remove(idx);
+      let (old_font, _) = self.fonts.remove(idx);
+      if !self.fonts.iter().any(|(font, _)| Typeface::equal(&old_font, font)) {
+        self.locked_fonts.retain(|locked| !Typeface::equal(&old_font, locked));
+      }
     }
 
     // add the new typeface/alias and recreate the FontCollection to include it
+    if locked {
+      self.locked_fonts.push(font.clone());
+    }
     self.fonts.push((font, alias));
     self.collection = None;
     self.collection_cache.drain();
@@ -281,7 +290,10 @@ impl FontLibrary{
 
     // if any of the matched typefaces is a variable font, create an instance that
     // matches the current weight settings and add it to a dynamic font mgr
-    if matches.iter().any(|font| font.variation_design_parameters().is_some()){
+    if matches.iter().any(|font|
+      font.variation_design_parameters().is_some() &&
+      !self.locked_fonts.iter().any(|locked| Typeface::equal(font, locked))
+    ){
       // memoize the generation of FontCollections for instanced variable fonts
       let key = CollectionKey::new(style);
       if let Some(collection) = self.collection_cache.get(&key){
@@ -293,6 +305,9 @@ impl FontLibrary{
       let mut dynamic = TypefaceFontProvider::new();
 
       for font in matches.into_iter(){
+        if self.locked_fonts.iter().any(|locked| Typeface::equal(&font, locked)) {
+          continue
+        }
         font.variation_design_parameters()
           .and_then(|params|{
             // find the weight axis
@@ -381,9 +396,17 @@ pub fn family(mut cx: FunctionContext) -> JsResult<JsValue> {
 pub fn addFamily(mut cx: FunctionContext) -> JsResult<JsValue> {
   let alias = opt_string_arg(&mut cx, 1);
   let filenames = cx.argument::<JsArray>(2)?.to_vec(&mut cx)?;
+  let indices = cx.argument::<JsArray>(3)?.to_vec(&mut cx)?;
+  let indices = floats_in(&mut cx, &indices).into_iter()
+    .map(|index| index as usize)
+    .collect::<Vec<usize>>();
+  if filenames.len() != indices.len() {
+    return cx.throw_error("Expected one collection index per font file")
+  }
   let results = JsArray::new(&mut cx, filenames.len());
 
   for (i, filename) in strings_in(&mut cx, &filenames).iter().enumerate(){
+    let collection_index = indices[i];
     let path = Path::new(&filename);
     let typeface = match fs::read(path){
       Err(why) => {
@@ -413,7 +436,7 @@ pub fn addFamily(mut cx: FunctionContext) -> JsResult<JsValue> {
         }.unwrap_or(bytes);
 
         FontLibrary::with_shared(|lib|
-          lib.mgr.new_from_data(&bytes, None)
+          lib.mgr.new_from_data(&bytes, Some(collection_index))
         )
       }
     };
@@ -426,7 +449,7 @@ pub fn addFamily(mut cx: FunctionContext) -> JsResult<JsValue> {
 
         // register the typeface
         FontLibrary::with_shared(|lib|
-          lib.add_typeface(font, alias.clone())
+          lib.add_typeface(font, alias.clone(), collection_index & 0xffff0000 != 0)
         );
       },
       None => {
@@ -441,6 +464,7 @@ pub fn addFamily(mut cx: FunctionContext) -> JsResult<JsValue> {
 pub fn reset(mut cx: FunctionContext) -> JsResult<JsUndefined> {
   FontLibrary::with_shared(|lib|{
     lib.fonts.clear();
+    lib.locked_fonts.clear();
     lib.collection = None;
     lib.collection_cache.drain();
   });

--- a/tests/suite/media.test.js
+++ b/tests/suite/media.test.js
@@ -364,6 +364,26 @@ describe("FontLibrary", ()=>{
     assert(!FontLibrary.has(alias))
   })
 
+  test("can register a locked named variable-font instance", ()=>{
+    const variable = 'tests/assets/Raleway/Raleway-VariableFont_wght.ttf'
+    const staticLight = 'tests/assets/Raleway/static/Raleway-Light.ttf'
+
+    const [instance] = FontLibrary.use('Named Light', {path:variable, namedInstance:3})
+    FontLibrary.use('Static Light', staticLight)
+    assert.equal(instance.weight, 300)
+    assert.deepEqual(FontLibrary.family('Named Light').weights, [300])
+
+    ctx.font = '400 40px "Static Light"'
+    const expected = ctx.measureText('Variable font instance').width
+    ctx.font = '300 40px "Named Light"'
+    const locked = ctx.measureText('Variable font instance').width
+    assert(Math.abs(locked - expected) < 0.05)
+    for (const weight of [400, 700]) {
+      ctx.font = `${weight} 40px "Named Light"`
+      assert.equal(ctx.measureText('Variable font instance').width, locked)
+    }
+  })
+
   test("can render woff2 fonts", ()=>{
     for (const ext of ['woff', 'woff2']){
       let woff = findFont("Monoton-Regular." + ext),


### PR DESCRIPTION
## What changed

- allow `FontLibrary.use()` sources to select a one-based OpenType `fvar` named instance
- pass that selection through Skia's collection-index convention
- keep explicitly selected instances locked instead of re-instancing them from later CSS weight requests
- report only the selected instance's actual weight from `FontLibrary.family()`

## Why

Some variable fonts use multiple axes for a named face, such as optical size plus weight. Registering the variable file and later selecting only `wght` loses the named instance's other coordinates. This makes it impossible to register a face such as `{ opsz: 14, wght: 300 }` faithfully.

The new API is additive:

```js
FontLibrary.use("Example Light", {
  path: "/path/to/variable-font.ttf",
  namedInstance: 3,
})
```

Existing string-path registration is unchanged.

## Validation

- `npm test` — 142 tests passed
- added coverage comparing a locked Raleway Light named instance with its static Light face across requested weights 300, 400, and 700
- manually verified a two-axis `{ opsz: 14, wght: 300 }` named instance retains identical metrics when the caller requests other CSS weights
